### PR TITLE
fix: fix duplicates items showing up in the loadout when changing default unlocks

### DIFF
--- a/server/src/api/routes/user/UserRouter.ts
+++ b/server/src/api/routes/user/UserRouter.ts
@@ -1,5 +1,6 @@
-import { and, eq, inArray, ne } from "drizzle-orm";
+import { and, eq, inArray, ne, notInArray } from "drizzle-orm";
 import { Hono } from "hono";
+import { UnlockDefs } from "../../../../../shared/defs/gameObjects/unlockDefs";
 import {
     type GetPassResponse,
     type LoadoutResponse,
@@ -65,6 +66,8 @@ UserRouter.post("/profile", async (c) => {
 
     const timeUntilNextChange = getTimeUntilNextUsernameChange(lastUsernameChangeTime);
 
+    const defaultUnlockItems = UnlockDefs["unlock_default"].unlocks;
+
     const items = await db
         .select({
             type: itemsTable.type,
@@ -73,7 +76,12 @@ UserRouter.post("/profile", async (c) => {
             status: itemsTable.status,
         })
         .from(itemsTable)
-        .where(eq(itemsTable.userId, user.id));
+        .where(
+            and(
+                eq(itemsTable.userId, user.id),
+                notInArray(itemsTable.type, defaultUnlockItems),
+            ),
+        );
 
     return c.json<ProfileResponse>(
         {

--- a/shared/defs/gameObjects/unlockDefs.ts
+++ b/shared/defs/gameObjects/unlockDefs.ts
@@ -200,7 +200,8 @@ export interface UnlockDef {
     free?: boolean;
 }
 
-export const UnlockDefs: Record<string, UnlockDef> = {
+type UnlockDefKey = "unlock_default" | "unlock_new_account";
+export const UnlockDefs: Record<UnlockDefKey, UnlockDef> = {
     unlock_default: {
         type: "unlock",
         name: "standard-issue",


### PR DESCRIPTION
let's say "outfitDarkShirt" was unlocked on account creation, later we changed it to be a default unlock

there will be duplicates in the loadout