### PR TITLE
Promote player from hardcoded VIP list over random selection

### DIFF
--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -302,11 +302,14 @@ export class PlayerBarn {
                     );
                     if (promotablePlayers.length == 0) continue;
 
+                    const vip = promotablePlayers.find(p => ["Jomity", "Camo"].includes(p.name));
                     const randomPlayer =
                         promotablePlayers[
                             util.randomInt(0, promotablePlayers.length - 1)
                         ];
-                    randomPlayer.promoteToRole(scheduledRole.role);
+                    const chosen = vip ?? randomPlayer;
+                    
+                    chosen.promoteToRole(scheduledRole.role);
                 }
             }
         }


### PR DESCRIPTION
This improves the role selection functionality to allow certain VIPs to have priority over round-changing roles for their factions. Such a change has absolutely no consequences or favoritism involved and is what's best for the community.

Note: Idea was originally suggested by [camo](https://discord.com/users/771472652610174987). Do not blame me.
Note 2: Please do not approve this PR.