### PR TITLE
Feat: building editor / viewer

### DIFF
--- a/client/building-editor/index.html
+++ b/client/building-editor/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang='en'>
+
+<head>
+  <meta charset='UTF-8'>
+  <title>survev.io Building Editor</title>
+  <meta name="viewport"
+    content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, viewport-fit=auto, user-scalable=no">
+  <link rel="icon" href="/favicon.ico" type="image/x-icon">
+  <link rel="stylesheet" href="./src/editor.css">
+</head>
+
+<body>
+  <div id="editor-ui"></div>
+  <canvas tabindex="1" id="cvs"></canvas>
+  <div id="game-touch-area" style="display: none;"></div>
+  <script type="module" src="./src/main.ts"></script>
+</body>
+
+</html>

--- a/client/building-editor/src/editor.css
+++ b/client/building-editor/src/editor.css
@@ -1,0 +1,47 @@
+html,
+body,
+canvas {
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+  width: 100%;
+}
+
+#editor-ui {
+  position: absolute;
+  left: 10px;
+  top: 10px;
+
+  /* Tweakpane theme */
+  --tp-base-background-color: hsla(0, 0%, 0%, 0.4);
+  --tp-base-shadow-color: hsla(0, 0%, 0%, 0.2);
+  --tp-button-background-color: hsl(177.47, 37.25%, 50%);
+  --tp-button-background-color-active: hsl(177.47, 37.25%, 60%);
+  --tp-button-background-color-focus: hsl(177.47, 37.25%, 60%);
+  --tp-button-background-color-hover: hsl(177.47, 37.25%, 40%);
+  --tp-button-foreground-color: hsla(0, 0%, 100%, 1);
+  --tp-container-background-color: hsla(0, 0%, 10%, 0.5);
+  --tp-container-background-color-active: hsla(0, 0%, 25%, 0.5);
+  --tp-container-background-color-focus: hsla(0, 0%, 20%, 0.5);
+  --tp-container-background-color-hover: hsla(0, 0%, 15%, 0.5);
+  --tp-container-foreground-color: hsla(0, 0%, 100%, 1);
+  --tp-groove-foreground-color: hsla(0, 0%, 10%, 1);
+  --tp-input-background-color: hsla(0, 0%, 90%, 1);
+  --tp-input-background-color-active: hsla(0, 0%, 85%, 1);
+  --tp-input-background-color-focus: hsla(0, 0%, 80%, 1);
+  --tp-input-background-color-hover: hsla(0, 0%, 75%, 1);
+  --tp-input-foreground-color: hsla(0, 0%, 0%, 1);
+  --tp-label-foreground-color: hsla(0, 0%, 100%, 1);
+  --tp-monitor-background-color: hsla(0, 0%, 8%, 1);
+  --tp-monitor-foreground-color: hsla(0, 3%, 90%, 1);
+}
+
+/* Invert the tweak panel slider background */
+.tp-sldv_t::before {
+  background-color: var(--in-fg) !important;
+}
+
+.tp-sldv_k::before {
+  background-color: var(--in-bg) !important;
+}

--- a/client/building-editor/src/editorDisplay.ts
+++ b/client/building-editor/src/editorDisplay.ts
@@ -1,0 +1,642 @@
+import * as PIXI from "pixi.js-legacy";
+import { MapObjectDefs } from "../../../shared/defs/mapObjectDefs";
+import type { BuildingDef, StructureDef } from "../../../shared/defs/mapObjectsTyping";
+import { MapMsg } from "../../../shared/net/mapMsg";
+import { type ObjectData, ObjectType } from "../../../shared/net/objectSerializeFns";
+import type { LocalDataWithDirty } from "./../../../shared/net/updateMsg";
+import { math } from "../../../shared/utils/math";
+import { assert, util } from "../../../shared/utils/util";
+import { type Vec2, v2 } from "../../../shared/utils/v2";
+import type { Ambiance } from "../../src/ambiance";
+import type { AudioManager } from "../../src/audioManager";
+import Camera from "../../src/camera";
+import type { ConfigManager, DebugRenderOpts } from "../../src/config";
+import { debugLines } from "../../src/debug/debugLines";
+import { device } from "../../src/device";
+import type { Game } from "../../src/game";
+import type { InputBinds } from "../../src/inputBinds";
+import { Map } from "../../src/map";
+import { DecalBarn } from "../../src/objects/decal";
+import { Creator } from "../../src/objects/objectPool";
+import { ParticleBarn } from "../../src/objects/particles";
+import { type Player, PlayerBarn } from "../../src/objects/player";
+import { SmokeBarn } from "../../src/objects/smoke";
+import { Renderer } from "../../src/renderer";
+import type { ResourceManager } from "../../src/resources";
+import type { UiManager2 } from "../../src/ui/ui2";
+
+export class EditorDisplay {
+    active = false;
+    initialized = false;
+
+    canvasMode!: boolean;
+    camera!: Camera;
+    renderer!: Renderer;
+    particleBarn!: ParticleBarn;
+    decalBarn!: DecalBarn;
+    map!: Map;
+    playerBarn!: PlayerBarn;
+    smokeBarn!: SmokeBarn;
+    objectCreator!: Creator;
+    debugDisplay!: PIXI.Graphics;
+
+    activeId = 98;
+    activePlayer!: Player;
+
+    nextId = 100;
+
+    mapMsg = new MapMsg();
+
+    getNextId() {
+        return this.nextId++;
+    }
+
+    constructor(
+        public pixi: PIXI.Application,
+        public audioManager: AudioManager,
+        public config: ConfigManager,
+        public inputBinds: InputBinds,
+        public ambience: Ambiance,
+        public resourceManager: ResourceManager,
+    ) {}
+
+    init() {
+        this.canvasMode = this.pixi.renderer.type == PIXI.RENDERER_TYPE.CANVAS;
+        this.camera = new Camera();
+        this.renderer = new Renderer(this as unknown as Game, this.canvasMode);
+        this.particleBarn = new ParticleBarn(this.renderer);
+        this.decalBarn = new DecalBarn();
+        this.map = new Map(this.decalBarn);
+        this.playerBarn = new PlayerBarn();
+        this.smokeBarn = new SmokeBarn();
+
+        // Register types
+        const TypeToPool = {
+            [ObjectType.Player]: this.playerBarn.playerPool,
+            [ObjectType.Obstacle]: this.map.m_obstaclePool,
+            [ObjectType.Building]: this.map.m_buildingPool,
+            [ObjectType.Structure]: this.map.m_structurePool,
+            [ObjectType.Decal]: this.decalBarn.decalPool,
+            [ObjectType.Smoke]: this.smokeBarn.m_smokePool,
+        };
+
+        this.objectCreator = new Creator();
+        for (const type in TypeToPool) {
+            if (TypeToPool.hasOwnProperty(type)) {
+                this.objectCreator.m_registerType(
+                    type,
+                    TypeToPool[type as unknown as keyof typeof TypeToPool],
+                );
+            }
+        }
+
+        // Render ordering
+        this.debugDisplay = new PIXI.Graphics();
+
+        const pixiContainers = [
+            this.map.display.ground,
+            this.renderer.layers[0],
+            this.renderer.ground,
+            this.renderer.layers[1],
+            this.renderer.layers[2],
+            this.renderer.layers[3],
+            this.debugDisplay,
+        ];
+        for (let i = 0; i < pixiContainers.length; i++) {
+            const container = pixiContainers[i];
+            if (container) {
+                container.interactiveChildren = false;
+                this.pixi.stage.addChild(container);
+            }
+        }
+
+        this.resetObj();
+
+        this.updatePlayer();
+
+        this.activePlayer = this.playerBarn.getPlayerById(this.activeId)!;
+        this.activePlayer.m_setLocalData({
+            boost: 100,
+            boostDirty: true,
+            hasAction: false,
+            health: 100,
+            inventoryDirty: false,
+            scopedIn: false,
+            spectatorCountDirty: false,
+            weapsDirty: true,
+            curWeapIdx: 2,
+            weapons: [
+                {
+                    name: "",
+                    ammo: 0,
+                },
+                {
+                    name: "",
+                    ammo: 0,
+                },
+                {
+                    name: "bayonet_rugged",
+                    ammo: 0,
+                },
+                {
+                    name: "",
+                    ammo: 0,
+                },
+            ],
+        } as unknown as LocalDataWithDirty);
+
+        this.activePlayer.layer = this.activePlayer.m_netData.m_layer;
+        this.renderer.setActiveLayer(this.activePlayer.layer);
+        this.audioManager.activeLayer = this.activePlayer.layer;
+
+        this.initialized = true;
+
+        this.resize();
+    }
+
+    free() {
+        if (this.initialized) {
+            this.map.m_free();
+            this.particleBarn.m_free();
+            this.renderer.m_free();
+            while (this.pixi.stage.children.length > 0) {
+                const e = this.pixi.stage.children[0];
+                this.pixi.stage.removeChild(e);
+                e.destroy({
+                    children: true,
+                });
+            }
+        }
+        this.initialized = false;
+    }
+
+    getCtx() {
+        return {
+            audioManager: this.audioManager,
+            renderer: this.renderer,
+            particleBarn: this.particleBarn,
+            map: this.map,
+            smokeBarn: this.smokeBarn,
+            decalBarn: this.decalBarn,
+        };
+    }
+
+    toWorldPos(pos: Vec2) {
+        const center = v2.create(this.map.width / 2, this.map.height / 2);
+
+        return v2.add(center, pos);
+    }
+
+    toBuildingPos(pos: Vec2) {
+        const center = v2.create(this.map.width / 2, this.map.height / 2);
+        return v2.sub(pos, center);
+    }
+
+    updatePlayer() {
+        const pos = this.toWorldPos(this.config.get("buildingEditor")!.pos);
+        const obj = {
+            outfit: "outfitDev",
+            backpack: "backpack02",
+            helmet: "helmet01",
+            chest: "chest03",
+            activeWeapon: "fists",
+            layer: 0,
+            dead: true,
+            downed: false,
+            animType: 0,
+            animSeq: 0,
+            actionSeq: 0,
+            actionType: 0,
+            actionItem: "",
+            wearingPan: false,
+            healEffect: false,
+            frozen: false,
+            frozenOri: 0,
+            hasteType: 0,
+            hasteSeq: 0,
+            scale: 1,
+            role: "",
+            perks: [],
+            pos: pos,
+            dir: v2.create(0, -1),
+        };
+
+        this.objectCreator.m_updateObjFull(
+            ObjectType.Player,
+            this.activeId,
+            obj as unknown as ObjectData<ObjectType.Player>,
+            this.getCtx(),
+        );
+
+        this.playerBarn.setPlayerInfo({
+            playerId: 98,
+            teamId: 1,
+            groupId: 0,
+            name: "",
+            loadout: {
+                heal: "heal_basic",
+                boost: "boost_basic",
+            },
+        });
+    }
+
+    setPlayerPos(pos: Vec2) {
+        this.objectCreator.m_updateObjPart(
+            this.activeId,
+            {
+                pos: pos,
+                dir: v2.create(0, -1),
+            },
+            this.getCtx(),
+        );
+    }
+
+    addStructure(type: string, pos: Vec2, ori: number) {
+        assert(MapObjectDefs[type]?.type === "structure");
+
+        const def = MapObjectDefs[type] as StructureDef;
+
+        const data: ObjectData<ObjectType.Structure> = {
+            type,
+            pos,
+            ori,
+            layerObjIds: [],
+            interiorSoundAlt: false,
+            interiorSoundEnabled: true,
+        };
+        const obj = this.objectCreator.m_updateObjFull(
+            ObjectType.Structure,
+            this.getNextId(),
+            data,
+            this.getCtx(),
+        );
+
+        for (let i = 0; i < def.layers.length; i++) {
+            const layerDef = def.layers[i];
+            this.addBuilding(
+                layerDef.type,
+                math.addAdjust(pos, layerDef.pos, ori),
+                (layerDef.ori + ori) % 4,
+                i,
+            );
+        }
+
+        return obj;
+    }
+
+    addBuilding(type: string, pos: Vec2, ori: number, layer: number) {
+        assert(MapObjectDefs[type]?.type === "building");
+
+        const data: ObjectData<ObjectType.Building> = {
+            type,
+            pos,
+            ori,
+            layer,
+            occupied: false,
+            ceilingDamaged: false,
+            ceilingDead: false,
+            hasPuzzle: false,
+            puzzleSolved: false,
+            puzzleErrSeq: 0,
+        };
+        const obj = this.objectCreator.m_updateObjFull(
+            ObjectType.Building,
+            this.getNextId(),
+            data,
+            this.getCtx(),
+        );
+        const def = MapObjectDefs[type] as BuildingDef;
+
+        for (const child of def.mapObjects) {
+            let partType = child.type;
+
+            if (typeof partType === "object") {
+                partType = util.weightedRandomObject(partType);
+            }
+            if (!partType) continue;
+
+            let partOri: number;
+            if (child.inheritOri === false) partOri = child.ori;
+            else partOri = (child.ori + ori) % 4;
+
+            const partPos = math.addAdjust(pos, child.pos, ori);
+
+            this.addAuto(
+                partType,
+                partPos,
+                layer,
+                partOri,
+                child.scale,
+                obj.__id,
+                !!child.puzzlePiece,
+            );
+        }
+
+        if (def.mapGroundPatches) {
+            for (const patch of def.mapGroundPatches) {
+                this.mapMsg.groundPatches.push({
+                    min: math.addAdjust(pos, patch.bound.min, ori),
+                    max: math.addAdjust(pos, patch.bound.max, ori),
+                    color: patch.color,
+                    roughness: patch.roughness ?? 0,
+                    offsetDist: patch.offsetDist ?? 0,
+                    order: patch.order ?? 0,
+                    useAsMapShape: patch.useAsMapShape ?? true,
+                });
+            }
+        }
+
+        return obj;
+    }
+
+    addObstacle(
+        type: string,
+        pos: Vec2,
+        ori: number,
+        scale: number,
+        layer: number,
+        parentId?: number,
+        puzzlePiece?: boolean,
+    ) {
+        assert(MapObjectDefs[type]?.type === "obstacle");
+
+        const data: ObjectData<ObjectType.Obstacle> = {
+            type,
+            pos,
+            ori,
+            scale,
+            layer,
+            healthT: 1,
+            dead: false,
+            isDoor: false,
+            door: {
+                open: false,
+                canUse: false,
+                locked: false,
+                seq: 0,
+            },
+            isButton: false,
+            button: {
+                onOff: false,
+                canUse: false,
+                seq: 0,
+            },
+            isPuzzlePiece: !!puzzlePiece,
+            parentBuildingId: parentId,
+            isSkin: false,
+            skinPlayerId: 0,
+        };
+        const obj = this.objectCreator.m_updateObjFull(
+            ObjectType.Obstacle,
+            this.getNextId(),
+            data,
+            this.getCtx(),
+        );
+        return obj;
+    }
+
+    addDecal(type: string, pos: Vec2, ori: number, scale: number, layer: number) {
+        assert(MapObjectDefs[type]?.type === "decal");
+
+        const data: ObjectData<ObjectType.Decal> = {
+            type,
+            pos,
+            ori,
+            scale,
+            layer,
+            goreKills: 0,
+        };
+        const obj = this.objectCreator.m_updateObjFull(
+            ObjectType.Decal,
+            this.getNextId(),
+            data,
+            this.getCtx(),
+        );
+        return obj;
+    }
+
+    addAuto(
+        type: string,
+        pos: Vec2,
+        layer: number,
+        ori: number,
+        scale: number,
+        parentId?: number,
+        puzzlePiece?: boolean,
+        ignoreMapSpawnReplacement?: boolean,
+    ) {
+        const def = MapObjectDefs[type];
+
+        const spawnReplacements = this.map.getMapDef().mapGen.spawnReplacements[0];
+        if (spawnReplacements[type] && !ignoreMapSpawnReplacement) {
+            type = spawnReplacements[type];
+        }
+
+        switch (def.type) {
+            case "obstacle":
+                return this.addObstacle(
+                    type,
+                    pos,
+                    ori,
+                    scale,
+                    layer,
+                    parentId,
+                    puzzlePiece,
+                );
+            case "building":
+                return this.addBuilding(type, pos, ori, layer);
+            case "structure":
+                return this.addStructure(type, pos, ori);
+            case "decal": {
+                return this.addDecal(type, pos, ori, scale, layer);
+            }
+            case "loot_spawner":
+                // nothing for now
+                break;
+        }
+    }
+
+    clearAllObjs() {
+        for (const obj of this.map.m_structurePool.m_getPool()) {
+            if (obj.active) {
+                this.objectCreator.m_deleteObj(obj.__id);
+            }
+        }
+
+        for (const obj of this.map.m_buildingPool.m_getPool()) {
+            if (obj.active) {
+                this.objectCreator.m_deleteObj(obj.__id);
+            }
+        }
+
+        for (const obj of this.map.m_obstaclePool.m_getPool()) {
+            if (obj.active) {
+                this.objectCreator.m_deleteObj(obj.__id);
+            }
+        }
+
+        for (const obj of this.decalBarn.decalPool.m_getPool()) {
+            if (obj.active) {
+                this.objectCreator.m_deleteObj(obj.__id);
+            }
+        }
+    }
+
+    resetObj() {
+        const cfg = this.config.get("buildingEditor")!;
+        const mapName = cfg.map;
+        const type = cfg.object;
+
+        this.resourceManager.loadMapAssets(mapName);
+
+        this.mapMsg = new MapMsg();
+        this.mapMsg.grassInset = 18;
+        this.mapMsg.groundPatches = [];
+        this.mapMsg.width = 720;
+        this.mapMsg.height = 720;
+        this.mapMsg.mapName = mapName;
+        this.mapMsg.objects = [];
+        this.mapMsg.places = [];
+        this.mapMsg.rivers = [];
+        this.mapMsg.seed = 218051654;
+        this.mapMsg.shoreInset = 48;
+
+        this.map.loadMap(this.mapMsg, this.camera, this.canvasMode, this.particleBarn);
+
+        this.clearAllObjs();
+        const center = v2.create(this.map.width / 2, this.map.height / 2);
+
+        if (type) {
+            this.addAuto(type, center, 0, 0, 1);
+        }
+
+        // re render the map so ground patches are rendered after the buildings are created
+        this.map.display.ground.clear();
+        this.map.renderTerrain(
+            this.map.display.ground,
+            2 / this.camera.m_ppu,
+            this.canvasMode,
+            false,
+        );
+    }
+
+    update(dt: number) {
+        const debug = this.config.get("debugRenderer")!;
+        const editorCfg = this.config.get("buildingEditor")!;
+        // Camera
+        this.camera.m_pos = v2.copy(this.activePlayer.m_pos);
+        this.camera.m_targetZoom = editorCfg.zoom;
+
+        this.camera.m_zoom = math.lerp(
+            dt * 5,
+            this.camera.m_zoom,
+            this.camera.m_targetZoom,
+        );
+
+        this.audioManager.cameraPos = v2.copy(this.camera.m_pos);
+
+        if (editorCfg.grid) {
+            const width = this.camera.m_screenWidth / this.camera.m_z();
+            const height = this.camera.m_screenHeight / this.camera.m_z();
+
+            const roundV2 = (v: Vec2) => {
+                return {
+                    x: Math.round(v.x / 10) * 10,
+                    y: Math.round(v.y / 10) * 10,
+                };
+            };
+            const size = v2.create(width, height);
+            const start = roundV2(v2.sub(this.camera.m_pos, size));
+            const end = roundV2(v2.add(this.camera.m_pos, size));
+
+            function addGrid(steps: number, color: number) {
+                for (let y = start.y; y < end.y; y += steps) {
+                    debugLines.addLine(v2.create(start.x, y), v2.create(end.x, y), color);
+                }
+                for (let x = start.x; x < end.x; x += steps) {
+                    debugLines.addLine(v2.create(x, start.y), v2.create(x, end.y), color);
+                }
+            }
+            if (this.camera.m_zoom >= 1.5) {
+                addGrid(1, 0x424242);
+            }
+            if (this.camera.m_zoom >= 4.5) {
+                addGrid(0.25, 0x424242);
+            }
+            addGrid(this.camera.m_zoom > 0.5 ? 5 : 10, 0x7f7f7f);
+
+            debugLines.addRay(this.camera.m_pos, v2.create(0, 1), 1, 0x00ff00);
+            debugLines.addRay(this.camera.m_pos, v2.create(1, 0), 1, 0x00ff00);
+        }
+
+        this.playerBarn.m_update(
+            dt,
+            this.activeId,
+            this.renderer,
+            this.particleBarn,
+            this.camera,
+            this.map,
+            this.inputBinds,
+            this.audioManager,
+            // ui2 manager is only used for updating perks, as long as we dont add any perks
+            // it should be fine :)
+            undefined as unknown as UiManager2,
+            false,
+            false,
+        );
+
+        this.map.m_update(
+            dt,
+            this.activePlayer,
+            this.playerBarn,
+            this.particleBarn,
+            this.audioManager,
+            this.ambience,
+            this.renderer,
+            this.camera,
+            [],
+            debug,
+        );
+
+        this.smokeBarn.m_update(
+            dt,
+            this.camera,
+            this.activePlayer,
+            this.map,
+            this.renderer,
+        );
+        this.particleBarn.m_update(dt, this.camera);
+        this.decalBarn.m_update(dt, this.camera, this.renderer);
+        this.renderer.m_update(dt, this.camera, this.map);
+        this.activePlayer.playActionStartSfx = false;
+
+        this.render(debug);
+    }
+
+    render(debug: DebugRenderOpts) {
+        const grassColor = this.map.mapLoaded
+            ? this.map.getMapDef().biome.colors.grass
+            : 8433481;
+
+        this.pixi.renderer.background.color = grassColor;
+
+        // Module rendering
+        this.playerBarn.m_render(this.camera, debug);
+        this.map.m_render(this.camera);
+
+        this.debugDisplay.clear();
+        if (debug.enabled) {
+            debugLines.m_render(this.camera, this.debugDisplay);
+        }
+        debugLines.flush();
+    }
+
+    resize() {
+        if (this.initialized) {
+            this.camera.m_screenWidth = device.screenWidth;
+            this.camera.m_screenHeight = device.screenHeight;
+            this.map.resize(this.pixi.renderer, this.canvasMode);
+            this.renderer.resize(this.map, this.camera);
+        }
+    }
+}

--- a/client/building-editor/src/editorDisplay.ts
+++ b/client/building-editor/src/editorDisplay.ts
@@ -616,7 +616,7 @@ export class EditorDisplay {
     render(debug: DebugRenderOpts) {
         const grassColor = this.map.mapLoaded
             ? this.map.getMapDef().biome.colors.grass
-            : 8433481;
+            : 0x80af49;
 
         this.pixi.renderer.background.color = grassColor;
 

--- a/client/building-editor/src/editorUi.ts
+++ b/client/building-editor/src/editorUi.ts
@@ -1,0 +1,291 @@
+import { type FolderApi, Pane, type TabPageApi } from "tweakpane";
+import { MapDefs } from "../../../shared/defs/mapDefs";
+import { MapObjectDefs } from "../../../shared/defs/mapObjectDefs";
+import { math } from "../../../shared/utils/math";
+import { v2 } from "../../../shared/utils/v2";
+import {
+    type BuildingEditorConfig,
+    type ConfigKey,
+    type ConfigManager,
+    type ConfigType,
+    debugRenderConfig,
+} from "../../src/config";
+import { type InputHandler, Key, MouseWheel } from "../../src/input";
+import type { EditorDisplay } from "./editorDisplay";
+
+function camelCaseToText(str: string) {
+    return str
+        .replace(/([A-Z])/g, " $1")
+        .split(" ")
+        .map((s) => {
+            return `${s.charAt(0).toUpperCase()}${s.substring(1)}`;
+        })
+        .join(" ");
+}
+
+const MIN_ZOOM = 0.3;
+const MAX_ZOOM = 10;
+const ZOOM_STEP = 0.2;
+
+export class EditorUi {
+    params: typeof BuildingEditorConfig;
+    renderParams: typeof debugRenderConfig;
+
+    pane: Pane;
+    zoomBind: ReturnType<Pane["addBinding"]>;
+    constructor(
+        public config: ConfigManager,
+        public display: EditorDisplay,
+    ) {
+        this.params = this.config.get("buildingEditor")!;
+        this.renderParams = this.config.get("debugRenderer")!;
+
+        const container = document.getElementById("editor-ui") as HTMLDivElement;
+
+        this.pane = new Pane({
+            container,
+            expanded: true,
+            title: "Editor",
+        });
+
+        const pane = this.pane;
+
+        // zoom
+        {
+            const addSlider = (key: keyof EditorUi["params"]) => {
+                const bind = pane.addBinding(this.params, key, {
+                    label: `${key.charAt(0).toUpperCase()}${key.substring(1)}`,
+                    min: MIN_ZOOM,
+                    max: MAX_ZOOM,
+                    step: ZOOM_STEP,
+                });
+                bind.on("change", (e) => {
+                    this.config.set("buildingEditor", this.params);
+                });
+                return bind;
+            };
+            this.zoomBind = addSlider("zoom");
+        }
+
+        // Position
+        {
+            const mapCenter = v2.create(
+                this.display.map.width / 2,
+                this.display.map.height / 2,
+            );
+
+            const posBind = pane.addBinding(this.params, "pos", {
+                x: {
+                    min: -mapCenter.x,
+                    max: mapCenter.x,
+                    step: 0.1,
+                },
+                y: {
+                    inverted: true,
+                    min: -mapCenter.y,
+                    max: mapCenter.y,
+                    step: 0.1,
+                },
+                picker: "inline",
+                label: "Camera Position",
+            });
+
+            const visualBind = {
+                pos: v2.create(0, 0),
+            };
+            const mousePosBind = pane.addBinding(visualBind, "pos", {
+                x: {
+                    min: -mapCenter.x,
+                    max: mapCenter.x,
+                    step: 0.1,
+                },
+                y: {
+                    inverted: true,
+                    min: -mapCenter.y,
+                    max: mapCenter.y,
+                    step: 0.1,
+                },
+                label: "Cursor Position",
+            });
+
+            let changePos = true;
+            posBind.on("change", (v) => {
+                if (changePos) {
+                    this.display.setPlayerPos(this.display.toWorldPos(v.value));
+                }
+                this.config.set("buildingEditor", this.params);
+            });
+
+            const canvas = this.display.pixi.view as HTMLCanvasElement;
+            canvas.addEventListener("mousemove", (e: MouseEvent) => {
+                if (e.buttons === 1) {
+                    canvas.style.cursor = "grabbing";
+                    const delta = v2.div(
+                        v2.create(e.movementX, -e.movementY),
+                        this.display.camera.m_z(),
+                    );
+                    const pos = v2.sub(this.display.activePlayer.m_pos, delta);
+
+                    pos.x = Math.round(pos.x * 10) / 10;
+                    pos.y = Math.round(pos.y * 10) / 10;
+
+                    this.display.setPlayerPos(pos);
+                    this.params.pos = this.display.toBuildingPos(pos);
+                    this.config.set("buildingEditor", this.params);
+                    posBind.refresh();
+                } else {
+                    canvas.style.cursor = "crosshair";
+                }
+
+                visualBind.pos = this.display.toBuildingPos(
+                    this.display.camera.m_screenToPoint(v2.create(e.clientX, e.clientY)),
+                );
+                mousePosBind.refresh();
+            });
+        }
+
+        // Map
+        {
+            const maps = Object.keys(MapDefs).reduce(
+                (a, key) => {
+                    a[key] = key;
+                    return a;
+                },
+                {} as Record<string, string>,
+            );
+            const mapBind = pane.addBinding(this.params, "map", {
+                options: maps,
+                label: "Map",
+            });
+            mapBind.on("change", (e) => {
+                if (MapDefs[e.value]) {
+                    this.config.set("buildingEditor", this.params);
+                    this.display.resetObj();
+                }
+            });
+        }
+
+        {
+            const avaliableObjects = Object.entries(MapObjectDefs)
+                .filter(([, def]) => {
+                    // we cant render loot spawner, also no point on spawning them individually
+                    if (def.type === "loot_spawner") return false;
+
+                    // too many walls
+                    if (def.type === "obstacle" && def.isWall) return false;
+
+                    return true;
+                })
+                .map(([key]) => key);
+
+            const bind = pane.addBinding(this.params, "object", {
+                label: "Type",
+            });
+            const input = bind.element.querySelector("input") as HTMLInputElement;
+
+            // don't want to trigger keybinds (like L to fullscreen) while typing
+            input.addEventListener("keyup", (e) => e.stopPropagation());
+            input.addEventListener("keydown", (e) => {
+                e.stopPropagation();
+
+                if (e.key == "Enter" && avaliableObjects.includes(input.value)) {
+                    this.params.object = input.value;
+                    this.config.set("buildingEditor", this.params);
+                    this.display.resetObj();
+                }
+            });
+            const button = pane.addButton({
+                title: "Spawn",
+            });
+            button.on("click", () => {
+                if (avaliableObjects.includes(input.value)) {
+                    this.config.set("buildingEditor", this.params);
+                    this.display.resetObj();
+                }
+            });
+
+            const dataList = document.createElement("datalist");
+            dataList.id = "editor-loot-list";
+            input.setAttribute("list", dataList.id);
+
+            input.parentElement?.appendChild(dataList);
+            for (const loot of avaliableObjects) {
+                const opt = document.createElement("option");
+                opt.value = loot;
+                dataList.appendChild(opt);
+            }
+        }
+
+        //
+        // Renderer
+        //
+
+        const addObject = (
+            // we pass both the default config object
+            // and the one we actually write to / loaded from local storage
+            // because if we always pass the one from LS to it may have keys that have been deleted
+            // and i dont want it to spam a bunch of deleted keys specially during development where
+            // i end up renaming keys a lot before deciding their final name :)
+            defaultObj: Record<string, unknown>,
+            outObj: Record<string, unknown>,
+            parentObj: Record<string, unknown>,
+            folder: FolderApi | TabPageApi,
+            configKey: ConfigKey,
+        ) => {
+            for (const key in defaultObj) {
+                const entry = defaultObj[key];
+
+                if (typeof entry === "object") {
+                    const folder2 = folder.addFolder({
+                        title: camelCaseToText(key),
+                        expanded: true,
+                    });
+                    addObject(
+                        entry as Record<string, unknown>,
+                        outObj[key] as Record<string, unknown>,
+                        parentObj,
+                        folder2,
+                        configKey,
+                    );
+                } else if (typeof entry === "boolean") {
+                    const label = camelCaseToText(key);
+
+                    const bind = folder.addBinding(outObj, key, {
+                        label,
+                    });
+                    bind.on("change", () => {
+                        this.config.set(configKey, parentObj as ConfigType[ConfigKey]);
+                    });
+                }
+            }
+        };
+        addObject(
+            debugRenderConfig,
+            this.renderParams,
+            this.renderParams,
+            this.pane,
+            "debugRenderer",
+        );
+    }
+
+    m_update(input: InputHandler) {
+        let zoom = this.params.zoom;
+
+        if (input.keyPressed(Key.Plus) || input.mouseWheelState === MouseWheel.Down) {
+            zoom -= ZOOM_STEP;
+        }
+
+        if (input.keyPressed(Key.Minus) || input.mouseWheelState === MouseWheel.Up) {
+            zoom += ZOOM_STEP;
+        }
+
+        zoom = math.clamp(zoom, MIN_ZOOM, MAX_ZOOM);
+        if (zoom !== this.params.zoom) {
+            this.params.zoom = zoom;
+            this.zoomBind.refresh();
+            this.config.set("buildingEditor", this.params);
+        }
+
+        this.config.config.debugRenderer = this.renderParams;
+    }
+}

--- a/client/building-editor/src/main.ts
+++ b/client/building-editor/src/main.ts
@@ -1,0 +1,181 @@
+import * as PIXI from "pixi.js-legacy";
+import { math } from "../../../shared/utils/math";
+import { Ambiance } from "../../src/ambiance";
+import { AudioManager } from "../../src/audioManager";
+import { ConfigManager } from "../../src/config";
+import { device } from "../../src/device";
+import { InputHandler } from "../../src/input";
+import { InputBinds } from "../../src/inputBinds";
+import { ResourceManager } from "../../src/resources";
+import { Localization } from "../../src/ui/localization";
+import { EditorDisplay } from "./editorDisplay";
+import { EditorUi } from "./editorUi";
+
+// we dont really need sounds
+// and loading them slows down page loading a lot
+// when they load... if we want them to load we also need to fix audio manager path anyway
+// so just do nothing :)
+class FakeAudioManager extends AudioManager {
+    preloadSounds() {}
+    loadSound() {}
+    playSound() {
+        return null;
+    }
+    playGroup() {
+        return null;
+    }
+    update() {}
+    updateSound() {}
+}
+
+class Application {
+    config = new ConfigManager();
+    localization = new Localization();
+
+    pixi?: PIXI.Application<PIXI.ICanvas>;
+    resourceManager?: ResourceManager;
+    input?: InputHandler;
+    inputBinds?: InputBinds;
+    editorDisplay?: EditorDisplay;
+
+    audioManager = new FakeAudioManager();
+    ambience = new Ambiance();
+
+    ui?: EditorUi;
+
+    domContentLoaded = false;
+    configLoaded = false;
+    initialized = false;
+    active = false;
+    hasFocus = true;
+
+    contextListener = function (e: MouseEvent) {
+        e.preventDefault();
+    };
+
+    constructor() {
+        const onLoadComplete = () => {
+            this.config.load(() => {
+                this.configLoaded = true;
+                this.tryLoad();
+            });
+        };
+        this.loadBrowserDeps(onLoadComplete);
+    }
+
+    loadBrowserDeps(onLoadCompleteCb: () => void) {
+        onLoadCompleteCb();
+    }
+
+    tryLoad() {
+        if (this.domContentLoaded && this.configLoaded && !this.initialized) {
+            this.initialized = true;
+            const language =
+                this.config.get("language") || this.localization.detectLocale();
+            this.config.set("language", language);
+            this.localization.setLocale(language);
+            this.localization.populateLanguageSelect();
+            this.localization.localizeIndex();
+
+            this.setAppActive(true);
+            const domCanvas = document.querySelector<HTMLCanvasElement>("#cvs")!;
+            const rendererRes = window.devicePixelRatio > 1 ? 2 : 1;
+
+            const createPixiApplication = (forceCanvas: boolean) => {
+                return new PIXI.Application({
+                    width: window.innerWidth,
+                    height: window.innerHeight,
+                    view: domCanvas,
+                    antialias: false,
+                    resolution: rendererRes,
+                    hello: true,
+                    forceCanvas,
+                });
+            };
+            let pixi = null;
+            try {
+                pixi = createPixiApplication(false);
+            } catch (_e) {
+                pixi = createPixiApplication(true);
+            }
+            this.pixi = pixi;
+            this.pixi.renderer.events.destroy();
+            this.pixi.ticker.add(this.update, this);
+            this.pixi.renderer.background.color = 7378501;
+            this.resourceManager = new ResourceManager(
+                this.pixi.renderer,
+                this.audioManager,
+                this.config,
+                "../",
+            );
+            this.resourceManager.loadMapAssets("main");
+            this.input = new InputHandler(document.getElementById("game-touch-area")!);
+            this.inputBinds = new InputBinds(this.input, this.config);
+            this.editorDisplay = new EditorDisplay(
+                this.pixi,
+                this.audioManager,
+                this.config,
+                this.inputBinds,
+                this.ambience,
+                this.resourceManager,
+            );
+            this.onResize();
+
+            this.onConfigModified();
+            this.config.addModifiedListener(this.onConfigModified.bind(this));
+
+            this.editorDisplay.init();
+
+            this.ui = new EditorUi(this.config, this.editorDisplay);
+        }
+    }
+
+    onResize() {
+        device.onResize();
+        this.pixi?.renderer.resize(device.screenWidth, device.screenHeight);
+        this.editorDisplay?.resize();
+    }
+
+    setAppActive(active: boolean) {
+        this.active = active;
+    }
+
+    onConfigModified(_key?: string) {}
+
+    update() {
+        const dt = math.clamp(this.pixi!.ticker.elapsedMS / 1000, 0.001, 1 / 8);
+        this.resourceManager!.update(dt);
+        this.ambience.update(dt, this.audioManager, !this.active);
+
+        if (this.editorDisplay?.initialized) {
+            this.editorDisplay.update(dt);
+        }
+        this.ui?.m_update(this.input!);
+
+        this.input!.flush();
+    }
+}
+
+const App = new Application();
+
+function onPageLoad() {
+    App.domContentLoaded = true;
+    App.tryLoad();
+}
+
+document.addEventListener("DOMContentLoaded", onPageLoad);
+window.addEventListener("load", onPageLoad);
+
+window.addEventListener("resize", () => {
+    App.onResize();
+});
+window.addEventListener("orientationchange", () => {
+    App.onResize();
+});
+
+window.addEventListener("onfocus", () => {
+    App.hasFocus = true;
+});
+window.addEventListener("onblur", () => {
+    App.hasFocus = false;
+});

--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -1,6 +1,8 @@
+import type { MapDefs } from "../../shared/defs/mapDefs";
 import { GameConfig } from "../../shared/gameConfig";
 import loadout from "../../shared/utils/loadout";
 import { util } from "../../shared/utils/util";
+import { v2 } from "../../shared/utils/v2";
 import type { Locale } from "./ui/localization";
 
 export const debugToolsConfig = {
@@ -67,6 +69,14 @@ export const debugHUDConfig = {
 
 export type DebugRenderOpts = typeof debugRenderConfig;
 
+export const BuildingEditorConfig = {
+    zoom: 1,
+    pos: v2.create(0, 0),
+    object: "house_red_01",
+    map: "main" as keyof typeof MapDefs,
+    grid: true,
+};
+
 const defaultConfig = {
     muteAudio: false,
     masterVolume: 1,
@@ -102,6 +112,7 @@ const defaultConfig = {
     debugRenderer: debugRenderConfig,
     /* STRIP_FROM_PROD_CLIENT:END */
     debugHUD: debugHUDConfig,
+    buildingEditor: BuildingEditorConfig,
 };
 
 export type ConfigType = typeof defaultConfig;

--- a/client/src/emote.ts
+++ b/client/src/emote.ts
@@ -607,7 +607,6 @@ export class EmoteBarn {
                     ping.playerId,
                     this.activePlayer.__id,
                     this.playerBarn,
-                    factionMode,
                 );
                 let indicator: Indicator | null = null;
                 let pingSound = pingData.sound!;

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -1022,7 +1022,7 @@ export class Game {
     m_render(dt: number, debug: DebugRenderOpts) {
         const grassColor = this.m_map.mapLoaded
             ? this.m_map.getMapDef().biome.colors.grass
-            : 8433481;
+            : 0x80af49;
         this.m_pixi.renderer.background.color = grassColor;
         // Module rendering
         this.m_playerBarn.m_render(this.m_camera, debug);

--- a/client/src/resources.ts
+++ b/client/src/resources.ts
@@ -43,8 +43,12 @@ function loadTexture(renderer: PIXI.IRenderer, url: string) {
     return baseTex;
 }
 
-function loadSpritesheet(renderer: PIXI.IRenderer, data: PIXI.ISpritesheetData) {
-    const baseTex = loadTexture(renderer, data.meta.image!);
+function loadSpritesheet(
+    renderer: PIXI.IRenderer,
+    basePath: string,
+    data: PIXI.ISpritesheetData,
+) {
+    const baseTex = loadTexture(renderer, basePath + data.meta.image!);
 
     const sheet = new PIXI.Spritesheet(baseTex, data);
     sheet.resolution = baseTex.resolution;
@@ -104,6 +108,7 @@ export class ResourceManager {
         public renderer: PIXI.IRenderer,
         public audioManager: AudioManager,
         public config: ConfigManager,
+        public basePath = "",
     ) {
         this.textureRes = selectTextureRes(this.renderer, this.config);
         PIXI.BasePrepare.uploadsPerFrame = 1;
@@ -145,7 +150,7 @@ export class ResourceManager {
 
         const atlasDef = atlasDefs[name];
         for (let i = 0; i < atlasDef.length; i++) {
-            const atlas = loadSpritesheet(this.renderer, atlasDef[i]);
+            const atlas = loadSpritesheet(this.renderer, this.basePath, atlasDef[i]);
             this.atlases[name].spritesheets.push(atlas);
         }
         this.atlases[name].loaded = true;

--- a/client/src/ui/opponentDisplay.ts
+++ b/client/src/ui/opponentDisplay.ts
@@ -291,12 +291,7 @@ export class LoadoutDisplay {
             dir: v2.create(0, -1),
         };
 
-        this.objectCreator.m_updateObjFull(
-            ObjectType.Player,
-            98,
-            obj as unknown as ObjectData<ObjectType.Player>,
-            ctx,
-        );
+        this.objectCreator.m_updateObjFull(ObjectType.Player, 98, obj, ctx);
 
         this.playerBarn.setPlayerInfo({
             playerId: 98,

--- a/client/src/ui/opponentDisplay.ts
+++ b/client/src/ui/opponentDisplay.ts
@@ -467,7 +467,7 @@ export class LoadoutDisplay {
     render(_dt: number, debug: DebugRenderOpts) {
         const grassColor = this.map.mapLoaded
             ? this.map.getMapDef().biome.colors.grass
-            : 8433481;
+            : 0x80af49;
 
         this.pixi.renderer.background.color = grassColor;
 

--- a/client/src/ui/ui.ts
+++ b/client/src/ui/ui.ts
@@ -1095,7 +1095,6 @@ export class UiManager {
         playerId: number,
         activePlayerId: number,
         playerBarn: PlayerBarn,
-        _factionMode: unknown,
     ) {
         const pingDef = PingDefs[pingType];
         if (pingDef) {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -12,6 +12,7 @@
     "./src/**/*.js",
     "../shared/",
     "./atlas-builder/**/*.ts",
+    "./building-editor/**/*.ts",
     "./global.d.ts"
   ]
 }

--- a/client/vite.config.mts
+++ b/client/vite.config.mts
@@ -77,10 +77,14 @@ export default defineConfig(({ mode }) => {
                 input: {
                     main: resolve(import.meta.dirname, "index.html"),
                     stats: resolve(import.meta.dirname, "stats/index.html"),
-                    "building-editor": resolve(
-                        import.meta.dirname,
-                        "building-editor/index.html",
-                    ),
+                    ...(isDev
+                        ? {
+                              "building-editor": resolve(
+                                  import.meta.dirname,
+                                  "building-editor/index.html",
+                              ),
+                          }
+                        : {}),
                 },
                 output: {
                     assetFileNames(assetInfo) {

--- a/client/vite.config.mts
+++ b/client/vite.config.mts
@@ -77,6 +77,10 @@ export default defineConfig(({ mode }) => {
                 input: {
                     main: resolve(import.meta.dirname, "index.html"),
                     stats: resolve(import.meta.dirname, "stats/index.html"),
+                    "building-editor": resolve(
+                        import.meta.dirname,
+                        "building-editor/index.html",
+                    ),
                 },
                 output: {
                     assetFileNames(assetInfo) {


### PR DESCRIPTION
well its more like a viewer than an editor since you cant like, move or add objects and colliders, you still have to edit the definition code :p

the idea is that it loads way way way faster than the game and saves the entire state (position, zoom, etc) so reloads are seamless 

so when editing a building definition code you can view the result as fast as possible after saving the file

and also its easier to measure units and get positions inside the editor since it has a grid and position info lines that are relative to the building center, so you dont have to guess where to place an obstacle or collider in the code