### PR TITLE
feat: old outfits added to base loot pool

### DIFF
--- a/shared/defs/mapObjectDefs.ts
+++ b/shared/defs/mapObjectDefs.ts
@@ -9977,7 +9977,11 @@ export const MapObjectDefs: Record<string, MapObjectDef> = {
     }),
     locker_03: createLocker({
         img: { sprite: "map-locker-03.img" },
-        loot: [autoLoot("ak47", 1), autoLoot("backpack02", 1), tierLoot("tier_khaki_outfit", 1, 1)],
+        loot: [
+            autoLoot("ak47", 1),
+            autoLoot("backpack02", 1),
+            tierLoot("tier_khaki_outfit", 1, 1),
+        ],
     }),
     oven_01: createOven({}),
     piano_01: {

--- a/shared/defs/maps/baseDefs.ts
+++ b/shared/defs/maps/baseDefs.ts
@@ -351,12 +351,12 @@ export const Main: MapDef = {
         tier_forest_helmet: [{ name: "helmet03_forest", count: 1, weight: 1 }],
         tier_outfits: [
             { name: "outfitCobaltShell", count: 1, weight: 0.2 }, // ?
-            { name: "outfitRed", count: 1, weight: 0.2}, // ?
-            { name: "outfitWhite", count: 1, weight: 0.2}, // ?
+            { name: "outfitRed", count: 1, weight: 0.2 }, // ?
+            { name: "outfitWhite", count: 1, weight: 0.2 }, // ?
             { name: "outfitKeyLime", count: 1, weight: 0.15 }, // ?
             { name: "outfitWoodland", count: 1, weight: 0.1 }, // ?
-            { name: "outfitCarbonFiber", count: 1, weight: 0.1}, // ?
-            { name: "outfitDarkGloves", count: 1, weight: 0.1}, // ?
+            { name: "outfitCarbonFiber", count: 1, weight: 0.1 }, // ?
+            { name: "outfitDarkGloves", count: 1, weight: 0.1 }, // ?
             { name: "outfitCamo", count: 1, weight: 0.1 }, // ?
             { name: "outfitGhillie", count: 1, weight: 0.01 }, // ?
         ],
@@ -609,9 +609,9 @@ export const Main: MapDef = {
             { name: "outfitVerde", count: 1, weight: 1 },
             { name: "outfitWoodland", count: 1, weight: 1 },
             { name: "outfitKeyLime", count: 1, weight: 1 },
-            { name: "outfitWhite", count: 1, weight: 1},
-            { name: "outfitCarbonFiber", count: 1, weight: 1},
-            { name: "outfitDarkGloves", count: 1, weight: 1},
+            { name: "outfitWhite", count: 1, weight: 1 },
+            { name: "outfitCarbonFiber", count: 1, weight: 1 },
+            { name: "outfitDarkGloves", count: 1, weight: 1 },
             { name: "outfitCamo", count: 1, weight: 1 },
         ],
         tier_airdrop_faction_outfits: [{ name: "outfitGhillie", count: 1, weight: 1 }],


### PR DESCRIPTION
This adds the following features:
The Professional, Carbon Fiber, Target Practice, and Arctic Avenger have been added back to the **tier_outfits** pool.
The Professional, Carbon Fiber, and Arctic Avenger have been added back to the **tier_faction_outfits** pool.
The Initiative has been added back to the **Initiative Locker** in the Chrysanthemum Bunker. Furthermore, **The Core Jumpsuit has been added** as a _very small chance_ to drop from the Initiative Locker, a change that wasn't in the original surviv.io.