### PR TITLE
Disable Auto-Pickup for Trick or Treat on Mobile

### DIFF
--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -1942,12 +1942,9 @@ export class Player extends BaseGameObject {
                         break;
                     }
                     case "perk": {
-                        if (!this.perks.find((perk) => perk.droppable)) {
-                            if(this.perks.find(
-                                (perk) => perk.replaceOnDeath === "halloween_mystery",
-                            )?.type) {
-                                break;
-                            }
+                        // Prevent mobile players from picking up potentially negative perks.
+                        // This includes non-droppable perks and halloween perks.
+                        if (!this.perks.find((perk) => perk.droppable && perk.replaceOnDeath !== "halloween_mystery")) {
                             this.pickupLoot(closestLoot);
                         }
                         break;


### PR DESCRIPTION
I don't know if this code fails in any hypothetical scenarios and I don't know how to code a new function that checks if the player has a Trick-or-Treat perk.

(I'm pretty sure hasPerk() doesn't work unless I want to spam a bunch of or statements)

i hope this code works