### PR TITLE
fix: user stats filter not working

### DIFF
--- a/client/src/stats/js/playerView.ts
+++ b/client/src/stats/js/playerView.ts
@@ -219,7 +219,7 @@ export class PlayerView {
     getUrlParams() {
         const params = new URLSearchParams(window.location.search);
         const slug = params.get("slug") || "";
-        const interval = params.get("t") || "alltime";
+        const interval = params.get("time") || "alltime";
         const mapId = params.get("mapId") || ALL_MAPS;
         const gameId = params.get("gameId") || "";
 


### PR DESCRIPTION

<img width="362" height="289" alt="image" src="https://github.com/user-attachments/assets/1da3d9f1-dd54-46b8-92af-85e805699478" />

this was introduced in 11f46e29.

I never liked the "t" to begin with.