### PR TITLE
fix (client): discord links, changelog

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1061,7 +1061,7 @@
                       <p class="news-paragraph">50v50 is back for another round, and getting straight to fighting is easier than ever: select guns are now <span class="highlight">bundled with ammo</span>.</p>
                       <p class="news-paragraph">Additionally, if a team leader fails to fire their flare soon after being promoted, it will now be <span class="highlight">auto-fired</span>.</p>
                       <p class="news-paragraph">A new role, the <span class="highlight">Captain</span>, has joined the ranks, but promotion to this role is not as easy as it seems. Lone Survivrs have also picked up a new perk: <span class="highlight">AP Rounds</span>.</p>
-                      <p class="news-paragraph">Enjoy a selection of role buffs and new gun world images. Let us know your thoughts by hopping into our <a href="https://discord.gg/6uRdCdkTPt">Discord server!</a></p>
+                      <p class="news-paragraph">Enjoy a selection of role buffs and new gun world images. Let us know your thoughts by hopping into our <a href="https://discord.gg/75RAK3p3K2">Discord server!</a></p>
                     </div>
                     <div data-date="2025-05-19">
                       <small class="news-date">May 19, 2025</small>
@@ -1069,7 +1069,7 @@
                       <p class="news-paragraph">Project COBALT has begun once again on the Island! Pick from one of <span class="highlight">six classes</span> and spawn in with special perks, then find <span class="highlight">class-pods</span> to gather unique class loot.</p>
                       <p class="news-paragraph">Be nimble and stealthy as the <span class="highlight">Scout</span>, unleash firepower as the <span class="highlight">Assault</span>, or stand your ground as the deflective <span class="highlight">Tank</span>. Team up with friends and form the perfect strategy, the group combinations are endless!</p>
                       <p class="news-paragraph"><span class="highlight">Accounts</span> have also returned! Personalize them with a unique name and emoji, and have the ability to track and <span class="highlight">view your stats</span> -- even gamemode specific! You can also view the <a href="/stats">leaderboards</a>.</p>
-                      <p class="news-paragraph">Need to assemble a classy squad? Make sure to join our <a href="https://discord.gg/6uRdCdkTPt">Discord server</a> to form the perfect team.</p>
+                      <p class="news-paragraph">Need to assemble a classy squad? Make sure to join our <a href="https://discord.gg/75RAK3p3K2">Discord server</a> to form the perfect team.</p>
                     </div>
                     <div data-date="2025-04-01">
                       <small class="news-date">April 01, 2025</small>
@@ -1096,7 +1096,7 @@
                       <p class="news-paragraph">50 vs 50 has arrived. To commemorate one of the bloodiest days in Island history, we're holding a field day (or week) of massive team versus team battles.</p>
                       <p class="news-paragraph">Join up alone or with a squad, and you'll be drafted into the Red Army or the Blue Group. Once both teams have locked in, one Leader will be randomly chosen for each side. Leader get a variety of perks, including a new gun and a new melee weapon! Leader pings are also visible and audible to every member of your team.</p>
                       <p class="news-paragraph">The enemy team isn't the only new danger in 50v50. Strike aircraft have been tasked with making frequent air strikes and you do not want to be caught in the bombing zone. Head indoors for relative safety, or attempt your best safety dance as the bombs fall around you.</p>
-                      <p class="news-paragraph">Will you rout the Red Army with a devastating flanking maneuver? Or will the Blue Group be crushed under the weight of a decisive pincer attack? Tell us your best war story on our <a href="https://discord.gg/6uRdCdkTPt">Discord server</a></p>
+                      <p class="news-paragraph">Will you rout the Red Army with a devastating flanking maneuver? Or will the Blue Group be crushed under the weight of a decisive pincer attack? Tell us your best war story on our <a href="https://discord.gg/75RAK3p3K2">Discord server</a></p>
                     </div>
                   </div>
                 </div>

--- a/client/src/sdk.ts
+++ b/client/src/sdk.ts
@@ -106,7 +106,7 @@ class SDKManager {
             $("#btn-discord-top-right").show();
             $(".surviv-shirts")
                 .css("background-image", "url(./img/discord-promo.png)")
-                .html(`<a href="https://discord.gg/6uRdCdkTPt" target="_blank"></a>`);
+                .html(`<a href="https://discord.gg/75RAK3p3K2" target="_blank"></a>`);
         } else {
             $(".btn-kofi").show();
             $(".surviv-shirts")

--- a/client/stats/index.html
+++ b/client/stats/index.html
@@ -130,7 +130,7 @@
               <a href='https://twitter.com/survevio' target='_blank' class='btn-social btn-darken btn-twitter'></a>
               <a href='https://reddit.com/r/survevio' target='_blank' class='btn-social btn-darken btn-reddit'></a>
               -->
-              <a href="https://discord.gg/6uRdCdkTPt" target="_blank" class="btn-social btn-darken btn-discord"></a>
+              <a href="https://discord.gg/75RAK3p3K2" target="_blank" class="btn-social btn-darken btn-discord"></a>
               <a href="https://ko-fi.com/survev" target="_blank" class="btn-social btn-darken btn-kofi"></a>
               <!-- <a href='https://www.youtube.com/c/survevio?sub_confirmation=1' target='_blank' class='btn-social btn-darken btn-youtube'></a> -->
             </div>


### PR DESCRIPTION
Changes:
- All discord links now direct to the 'new' server.
- Date for Birthday mode release changed from "Xth" to "21st."
- Used standard apostrophe in place of smart apostrophe.