### PR TITLE
chore: changelog

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1039,7 +1039,7 @@
                 <div id="news-block" class="menu-block">
                   <div id="news">
                     <h3 class="news-header">What's New!</h3>
-                    <div id="news-current" data-date="2025-10-XX">
+                    <div id="news-current" data-date="2025-10-21">
                       <small class="news-date">October 21st, 2025</small>
                       <p class="news-paragraph"><strong>Anniversary Harvest</strong></p>
                       <p class="news-paragraph">A strange irregularity emanating from the center of the island has led to the temporal displacement of survevrs back to <span class="highlight">October 2017</span>... perfectly coinciding with <span class="highlight">surviv's birthday!</span></p>

--- a/client/public/changelogRec.html
+++ b/client/public/changelogRec.html
@@ -25,6 +25,14 @@
 - More gamemodes.
 - Survevr Pass.
 
+## [0.1.31] - December 9th, 2025
+- Updated world images for the Mosin Nagant, Vector (9mm), Vector (.45 ACP), Peacemaker, Model 94, BLR 81, SCAR-H, Scout Elite, and M1100.
+- Fixed an issue with promotion giving certain items before giving a backpack.
+- Fixed an issue that caused tree sprites to be invisible when Turkey and Woods were both in rotation.
+- Adjusted Mosin cache in Turkey to better fit the mode.
+- Replaced berry bush cache with leaf pile cache in Turkey.
+- Survivr Pass 1 outfits now drop on death (to be reverted when the pass is released).
+
 ## [0.1.3] - October 21st, 2025
 - New mode: Birthday.
 - Updated Turkey map.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "survev",
-  "version": "0.1.3",
+  "version": "0.1.31",
   "type": "module",
   "description": "Open Source Surviv.io Server",
   "scripts": {


### PR DESCRIPTION
0.1.31 changelog
'Xth' fix in changelog is omitted as it's updated in Swifty's bugfix PR (see #291)