### PR TITLE
Bush Fix (Turkey)

### DIFF
--- a/shared/defs/mapObjectDefs.ts
+++ b/shared/defs/mapObjectDefs.ts
@@ -13211,6 +13211,24 @@ export const MapObjectDefs: Record<string, MapObjectDef> = {
         ],
         map: { displayType: "bush_06" },
     }),
+    cache_03tr: createCache({
+        mapObjects: [
+            {
+                type: "bush_06tr",
+                pos: v2.create(0, 0),
+                scale: 1,
+                ori: 0,
+            },
+            {
+                type: "loot_tier_leaf_pile",
+                pos: v2.create(0, 0),
+                scale: 1,
+                ori: 0,
+                inheritOri: false,
+            },
+        ],
+        map: { displayType: "bush_06" },
+    }),
     cache_06: createCache({
         mapObjects: [
             {

--- a/shared/defs/maps/turkeyDefs.ts
+++ b/shared/defs/maps/turkeyDefs.ts
@@ -52,7 +52,7 @@ const mapDef: PartialMapDef = {
                 crate_02: 3,
                 crate_03: 7,
                 bush_06tr: 70, // leaf pile turkey (without loot)
-                cache_03: 50, // leaf pile with loot
+                cache_03tr: 50, // leaf pile with loot
                 tree_07: 20,
                 tree_08: 170,
                 tree_08b: 4,


### PR DESCRIPTION
Fixed invisible cache bushes by creating a new cache. New cache uses bush-06tr sprite instead of bush-06 (woods) to be more consistent with the mode and included in the turkey atlas. 