### PR TITLE
Game Moderatr suit -> noDrop: true

### DIFF
--- a/shared/defs/gameObjects/outfitDefs.ts
+++ b/shared/defs/gameObjects/outfitDefs.ts
@@ -239,6 +239,7 @@ const SkinDefs: Record<string, OutfitDef> = {
     }),
     outfitMod: defineOutfitSkin("outfitBase", {
         name: "Game Moderatr",
+        noDrop: true,
         noDropOnDeath: true,
         skinImg: {
             baseTint: 0x3393db,


### PR DESCRIPTION
I made this change cause i think that this modification is important.
First of all: when playing with mod suit, if you were missclicking with an another stuff and then random player stole this mod suite, this will make confusion into the game itself. An scenario of an cheater (for example) with the moderator suite will be chaotic. And second one, i'm think that, when game moderator start to use the suite, they have to assume the skin for the entire game.