### PR TITLE
fix: avoid attempting to read the lost_game_data directory if it doesn't exist

### DIFF
--- a/server/src/gameServer.ts
+++ b/server/src/gameServer.ts
@@ -1,4 +1,5 @@
 import { App, SSLApp, type WebSocket } from "uWebSockets.js";
+import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { Cron } from "croner";
@@ -127,6 +128,9 @@ class GameServer {
         const games: SaveGameBody["matchData"] = [];
 
         const dir = path.resolve("lost_game_data");
+
+        if (!existsSync(dir)) return;
+
         const files = await fs.readdir(dir);
 
         for (const fileName of files) {


### PR DESCRIPTION
this was spamming the webhook