### PR TITLE
feat (modding): finish ModAPI v1.0 and docs

### DIFF
--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -1,0 +1,91 @@
+# Introduction
+
+Hi! This is a ModAPI created for survev.io, designed to provide a stable and predictable way for mods to interact with the game.
+
+Mods interact with the game through event hooks (on*), read-only accessors (get*), and a small set of intentionally limited modification hooks (set*).
+
+# How Mods Work
+
+Mods register callbacks using on* hooks. These hooks fire in response to specific game events, allowing mods to react by running their own logic.
+
+(Yes, you *can* try to make a dancing chicken appear each time someone dies. No judgement here...)
+
+Mods can read certain pieces of game state using get* functions. All data returned by these functions is read-only and represents a snapshot of the current state.
+
+(Think of it like looking through your neighbors window, nice view but you can't take their TV.)
+
+In limited cases, mods may also modify certain aspects of the game using set* functions. These APIs are intentionally constrained to prevent instability or unintended side effects.
+
+(Alas you cannot replace textures that other players (without your mod) would see. So your dream of making the whole map completely filled with water will have to wait...)
+
+# History / Background
+
+Historically mods for survev.io (and even surviv.io) relied on either monkeypatching what was needed, or if more powerful hooks were needed then entire code patching. While this allowed practically any type of reasonable mod to be created, these hooks were often brittle and prone to breaking upon updates.
+
+The goal of this ModAPI project is to get rid of that brittleness, within reasonable boundaries, while still allowing mod authors plenty of creativity in their creations.
+
+(Or, if we really wanted to go back to the stone age, we could create stuff like [this](https://github.com/chickenpoo351/Survev-Bundle-Patcher). An extreme example of automated code replacement for modding the game...)
+
+# Table of Contents
+
+- [on* hooks](#on-hooks)
+  - [Introduction to on* hooks](#introduction-to-on-hooks)
+  - [Game state hooks](#game-state-hooks)
+    - [onGameStart](#ongamestart)
+    - [onGameEnd](#ongameend)
+  - [Player state hooks](#player-state-hooks)
+    - [onPlayerDeath](#onplayerdeath)
+    - [onPlayerShoot](#onplayershoot)
+    - [onLocalPlayerShoot](#onlocalplayershoot)
+    - [onPlayerKill](#onplayerkill)
+    - [onLocalPlayerHeal](#onlocalplayerheal)
+    - [onLocalPlayerDamage](#onlocalplayerdamage)
+- [get* hooks](#get-hooks)
+  - [Introduction to get* hooks](#introduction-to-get-hooks)
+  - [Player info hooks](#player-info-hooks)
+    - [getPlayerKills](#getplayerkills)
+    - [getLocalPlayerHealth](#getlocalplayerhealth)
+    - [getLocalPlayerDamage](#getlocalplayerdamage)
+    - [getLocalPlayerHeal](#getlocalplayerheal)
+    - [getLocalPlayerHealRaw](#getlocalplayerhealraw)
+
+
+# on* hooks
+
+## Introduction to on* hooks
+
+## Game state hooks
+
+### onGameStart
+
+### onGameEnd
+
+## Player state hooks
+
+### onPlayerDeath
+
+### onPlayerShoot
+
+### onLocalPlayerShoot
+
+### onPlayerKill
+
+### onLocalPlayerHeal
+
+### onLocalPlayerDamage
+
+# get* hooks
+
+## Introduction to get* hooks
+
+## Player info hooks
+
+### getPlayerKills
+
+### getLocalPlayerHealth
+
+### getLocalPlayerDamage
+
+### getLocalPlayerHeal
+
+### getLocalPlayerHealRaw

--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -52,13 +52,109 @@ The goal of this ModAPI project is to get rid of that brittleness, within reason
 
 # on* hooks
 
+This section contains everything needed to know about on* type hooks.
+
 ## Introduction to on* hooks
+
+on* hooks are quite simple once you get to know them, allow me to explain.
+
+These hooks follow quite simple rules first off practically all of these hooks are used like this. 
+
+    // onGameStart() hook used for example.
+    // As well modAPI will be the object that will equal window.__MYGAME_MOD_API__ just for simplicity of the example of course though, you can name this anything you want or just use the window object.
+
+    const modAPI = window.__MYGAME_MOD_API__
+
+    modAPI.onGameStart(() => {
+      // Your logic here to run upon game start.
+    })
+
+As you can see it is really quite simple of course there are a few things you should know.
+
+- First off, hooks are **synchronous**.
+
+- Secondly, execution order **between multiple hooks** must not be relied upon.
+
+Now what do those exactly mean? Lets start with hooks being synchronous.
+
+What this means is if you have an example like this 
+
+    const modAPI = window.__MYGAME_MOD_API__
+
+    modAPI.onGameStart(() => {
+      // perhaps you have logic here to play a sound
+    })
+
+    modAPI.onGameStart(() => {
+      // perhaps you have logic here to show an image
+    })
+
+These will *not* fire at the same time. Instead, each hook callback will execute only after the previous callback of the same type has finished executing.
+
+The callbacks are executed in the **order they were registered**. However, because mod load and registration order is not guaranteed, you should **not rely on a specific execution order between multiple hooks**.
+For this reason, it is generally recommended that you only use one on* hook of each type.
+
+**Note**: Execution order is only predictable within a single script. If a user installs additional mods that use the same hooks, the order in which each mods callbacks run may differ.
 
 ## Game state hooks
 
+This section contains every on* hook related to game state.
+
 ### onGameStart
 
+**When does this fire?**  
+Fires once at the start of a game round, after the game has initialized but before active gameplay begins.
+
+**How often does it fire?**  
+Once per game round.
+
+**Common use cases**
+- Initializing mod state
+- Setting up UI elements
+- Registering textures or assets
+- Playing intro sounds or animations
+
+**Example use**
+    
+    const modAPI = window.__MYGAME_MOD_API__
+
+    modAPI.onGameStart(() => {
+      // logic to run upon game start
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
+
 ### onGameEnd
+
+**When does this fire?**  
+Fires once at the end of a game round, after active gameplay has ended.
+
+**How often does it fire?**  
+Once per game round.
+
+**Common use cases**
+- Preparing mod for menu interactions
+- Setting up UI elements
+- Registering textures or assets
+- Playing exit sounds or animations
+
+**Example use**
+    
+    const modAPI = window.__MYGAME_MOD_API__
+
+    modAPI.onGameEnd(() => {
+      // logic to run upon game end
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
 
 ## Player state hooks
 

--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -34,20 +34,45 @@ The goal of this ModAPI project is to get rid of that brittleness, within reason
     - [onGameStart](#ongamestart)
     - [onGameEnd](#ongameend)
   - [Player state hooks](#player-state-hooks)
-    - [onPlayerDeath](#onplayerdeath)
+    - [onLocalPlayerDeath](#onLocalplayerdeath)
     - [onPlayerShoot](#onplayershoot)
     - [onLocalPlayerShoot](#onlocalplayershoot)
-    - [onPlayerKill](#onplayerkill)
+    - [onLocalPlayerKill](#onlocalplayerkill)
     - [onLocalPlayerHeal](#onlocalplayerheal)
     - [onLocalPlayerDamage](#onlocalplayerdamage)
+    - [onLocalPlayerInventoryItemChange](#onlocalplayerinventoryitemchange)
+    - [onLocalPlayerHelmetChange](#onlocalplayerhelmetchange)
+    - [onLocalPlayerChestChange](#onlocalplayerchestchange)
+    - [onLocalPlayerBackpackChange](#onlocalplayerbackpackchange)
+    - [onLocalPlayerOutfitChange](#onlocalplayeroutfitchange)
+    - [onLocalPlayerGearChange](#onlocalplayergearchange)
+    - [onLocalPlayerEquippedWeaponChange](#onlocalplayerequippedweaponchange)
+    - [onLocalPlayerWeaponChange](#onlocalplayerweaponchange)
+    - [onLocalPlayerWeaponAmmoUse](#onlocalplayerweaponammouse)
+    - [onLocalPlayerWeaponAmmoGained](#onlocalplayerweaponammogained)
+    - [onLocalPlayerRemovedItem](#onlocalplayerremoveditem)
+    - [onLocalPlayerAddedItem](#onlocalplayeraddeditem)
 - [get* hooks](#get-hooks)
   - [Introduction to get* hooks](#introduction-to-get-hooks)
   - [Player info hooks](#player-info-hooks)
-    - [getPlayerKills](#getplayerkills)
+    - [getLocalPlayerKills](#getlocalplayerkills)
     - [getLocalPlayerHealth](#getlocalplayerhealth)
     - [getLocalPlayerDamage](#getlocalplayerdamage)
     - [getLocalPlayerHeal](#getlocalplayerheal)
     - [getLocalPlayerHealRaw](#getlocalplayerhealraw)
+    - [getLocalPlayerRemovedItem](#getlocalplayerremoveditem)
+    - [getLocalPlayerAddedItem](#getlocalplayeraddeditem)
+    - [getLocalPlayerHelmet](#getlocalplayerhelmet)
+    - [getLocalPlayerChest](#getlocalplayerchest)
+    - [getLocalPlayerBackpack](#getlocalplayerbackpack)
+    - [getLocalPlayerOutfit](#getlocalplayeroutfit)
+    - [getLocalPlayerLastChangedGear](#getlocalplayerlastchangedgear)
+    - [getLocalPlayerGear](#getlocalplayergear)
+    - [getLocalPlayerCurrentEquippedWeapon](#getlocalplayercurrentequippedweapon)
+    - [getLocalPlayerLastChangedWeapon](#getlocalplayerlastchangedweapon)
+    - [getLocalPlayerWeaponAmmoUsed](#getlocalplayerweaponammoused)
+    - [getLocalPlayerWeaponAmmoGained](#getlocalplayerweaponammogained)
+    - [getLocalPlayerWeapons](#getlocalplayerweapons)
 
 
 # on* hooks
@@ -61,9 +86,9 @@ on* hooks are quite simple once you get to know them, allow me to explain.
 These hooks follow quite simple rules first off practically all of these hooks are used like this. 
 
     // onGameStart() hook used for example.
-    // As well modAPI will be the object that will equal window.__MYGAME_MOD_API__ just for simplicity of the example of course though, you can name this anything you want or just use the window object.
+    // As well modAPI will be the object that will equal window.survevModAPI just for simplicity of the example of course though, you can name this anything you want or just use the window object.
 
-    const modAPI = window.__MYGAME_MOD_API__
+    const modAPI = window.survevModAPI
 
     modAPI.onGameStart(() => {
       // Your logic here to run upon game start.
@@ -79,7 +104,7 @@ Now what do those exactly mean? Lets start with hooks being synchronous.
 
 What this means is if you have an example like this 
 
-    const modAPI = window.__MYGAME_MOD_API__
+    const modAPI = window.survevModAPI
 
     modAPI.onGameStart(() => {
       // perhaps you have logic here to play a sound
@@ -116,7 +141,7 @@ Once per game round.
 
 **Example use**
     
-    const modAPI = window.__MYGAME_MOD_API__
+    const modAPI = window.survevModAPI
 
     modAPI.onGameStart(() => {
       // logic to run upon game start
@@ -144,7 +169,7 @@ Once per game round.
 
 **Example use**
     
-    const modAPI = window.__MYGAME_MOD_API__
+    const modAPI = window.survevModAPI
 
     modAPI.onGameEnd(() => {
       // logic to run upon game end
@@ -158,17 +183,41 @@ Once per game round.
 
 ## Player state hooks
 
-### onPlayerDeath
+### onLocalPlayerDeath
 
 ### onPlayerShoot
 
 ### onLocalPlayerShoot
 
-### onPlayerKill
+### onLocalPlayerKill
 
 ### onLocalPlayerHeal
 
 ### onLocalPlayerDamage
+
+### onLocalPlayerInventoryItemChange
+
+### onLocalPlayerHelmetChange
+
+### onLocalPlayerChestChange
+
+### onLocalPlayerBackpackChange
+
+### onLocalPlayerOutfitChange
+
+### onLocalPlayerGearChange
+
+### onLocalPlayerEquippedWeaponChange
+
+### onLocalPlayerWeaponChange
+
+### onLocalPlayerWeaponAmmoUse
+
+### onLocalPlayerWeaponAmmoGained
+
+### onLocalPlayerRemovedItem
+
+### onLocalPlayerAddedItem
 
 # get* hooks
 
@@ -176,7 +225,7 @@ Once per game round.
 
 ## Player info hooks
 
-### getPlayerKills
+### getLocalPlayerKills
 
 ### getLocalPlayerHealth
 
@@ -185,3 +234,29 @@ Once per game round.
 ### getLocalPlayerHeal
 
 ### getLocalPlayerHealRaw
+
+### getLocalPlayerRemovedItem
+
+### getLocalPlayerAddedItem
+
+### getLocalPlayerHelmet
+
+### getLocalPlayerChest
+
+### getLocalPlayerBackpack
+
+### getLocalPlayerOutfit
+
+### getLocalPlayerLastChangedGear
+
+### getLocalPlayerGear
+
+### getLocalPlayerCurrentEquippedWeapon
+
+### getLocalPlayerLastChangedWeapon
+
+### getLocalPlayerWeaponAmmoUsed
+
+### getLocalPlayerWeaponAmmoGained
+
+### getLocalPlayerWeapons

--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -502,23 +502,258 @@ Once per outfit change.
 
 ### onLocalPlayerGearChange
 
+**When does this fire?**  
+Fires once when *any* of the local player’s gear changes (equipped, removed, or replaced).
+
+**How often does it fire?**  
+Once per gear change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Gear tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerGearChange(() => {
+      // logic to run upon local player gear change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
+
 ### onLocalPlayerEquippedWeaponChange
+
+**When does this fire?**  
+Fires once when the local player’s equipped weapon changes (equipped, removed, or replaced).
+
+**How often does it fire?**  
+Once per equipped weapon change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Weapon tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerEquippedWeaponChange(() => {
+      // logic to run upon local player equipped weapon change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is only for the equipped weapon. View the [onLocalPlayerWeaponChange](#onlocalplayerweaponchange) hook for any weapon change.
+
+---
 
 ### onLocalPlayerWeaponChange
 
+**When does this fire?**  
+Fires once when the local player’s weapon changes (equipped, removed, or replaced).
+
+**How often does it fire?**  
+Once per weapon change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Weapon tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerWeaponChange(() => {
+      // logic to run upon local player weapon change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is for any weapon change. View the [onLocalPlayerEquippedWeaponChange](#onlocalplayerequippedweaponchange) hook for the equipped weapon change.
+
+---
+
 ### onLocalPlayerWeaponAmmoUse
+
+**When does this fire?**  
+Fires once when the local player’s weapon ammo is used.
+
+**How often does it fire?**  
+Once per weapon ammo change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Weapon ammo tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerWeaponAmmoUse(() => {
+      // logic to run upon local player weapon ammo use
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook can fire frequently during active combat. Keep logic lightweight to avoid performance issues.
+
+---
 
 ### onLocalPlayerWeaponAmmoGained
 
+**When does this fire?**  
+Fires once when the local player’s weapon gains ammo.
+
+**How often does it fire?**  
+Once per weapon ammo change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Weapon ammo tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerWeaponAmmoGained(() => {
+      // logic to run upon local player weapon ammo gained
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook can fire frequently during active combat. Keep logic lightweight to avoid performance issues.
+
+---
+
 ### onLocalPlayerRemovedItem
+
+**When does this fire?**  
+Fires once when an item in the local player's inventory is removed (dropped, used, etc).
+
+**How often does it fire?**  
+Once per item removed.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Inventory tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerRemovedItem(() => {
+      // logic to run upon local player removed item
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
 
 ### onLocalPlayerAddedItem
 
+**When does this fire?**  
+Fires once when an item in the local player's inventory is added (picked up, given, etc).
+
+**How often does it fire?**  
+Once per item added.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Inventory tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerAddedItem(() => {
+      // logic to run upon local player added item
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
+
 # get* hooks
+
+This section contains everything needed to know about get* hooks.
 
 ## Introduction to get* hooks
 
+get* hooks are the *read only* side of the ModAPI. They allow mods to **query the current game state at any time** without subscribing to events or modifying anything.
+
+Unlike on* hooks, get* hooks do not fire automatically. Instead they return a snapshot of the current state **at the moment you call them**.
+
+In other words:
+
+- on* hooks tell you *when something happened*
+- get* hooks tell you *what the state looks like right now*
+
+If on* hooks are notifications, get* hooks are questions.
+
+All get* hooks are simple function calls that immediantly return data as seen here.
+
+    // getLocalPlayerKills and getLocalPlayerHealth used as examples
+    const modAPI = window.survevModAPI
+
+    const kills = modAPI.getLocalPlayerKills();
+    const health = modAPI.getLocalPlayerHealth();
+
+There is no registration, no callbacks, and no lifecycle to manage. Call them whenever you need information.
+
+All values returned by get* hooks are read only. Modifying the returned data will not affect the game.
+
+This is 100% intentional.
+
+get* hooks return the current known state, not historical data.
+
+For example:
+
+- `getLocalPlayerHealth()` returns the *current* health value
+- it does **not** tell *when* or *why* that health changed
+
+If you need timing, historical data collection, or event context, combine get* hooks with on* hooks like so:
+
+    // onLocalPlayerDamage and getLocalPlayerHealth used as examples
+
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerDamage(() => {
+      const newHealth = getLocalPlayerHealth();
+      // now do whatever you like with that info
+    })
+
+This pattern of using on* and get* hooks is the recommended way to build most mods.
+
 ## Player info hooks
+
+This section contains every get* hook related to the player.
 
 ### getLocalPlayerKills
 

--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -757,19 +757,264 @@ This section contains every get* hook related to the player.
 
 ### getLocalPlayerKills
 
+**What does this return?**  
+Returns the current kill count of the local player.
+
+**When is this updated?**  
+Updates automatically whenever the local player is credited a kill.
+
+**Return value**
+- `object`
+  - `totalKills` (`number`) - The local player’s current kill count
+
+**Common use cases**
+- Rendering kill counters or overlays
+- kill-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const kills = modAPI.getLocalPlayerKills()
+    console.log(kills.totalKills)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerHealth
+
+**What does this return?**  
+Returns the current health of the local player.
+
+**When is this updated?**  
+Updates automatically whenever the local player's health changes.
+
+**Return value**
+- `object`
+  - `totalHealth` (`number`) - The local player’s current health
+
+**Common use cases**
+- Rendering health counters or overlays
+- health-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const health = modAPI.getLocalPlayerHealth()
+    console.log(health.totalHealth)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
 
 ### getLocalPlayerDamage
 
+**What does this return?**  
+Returns the last damage amount the local player took.
+
+**When is this updated?**  
+Updates automatically whenever the local player takes damage.
+
+**Return value**
+- `object`
+  - `totalDamage` (`number`) - Amount of damage from the most recent damage event
+
+**Common use cases**
+- Rendering health counters or overlays
+- health-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const damageTaken = modAPI.getLocalPlayerDamage()
+    console.log(damageTaken.totalDamage)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerHeal
+
+**What does this return?**  
+Returns the last heal amount the local player took.
+
+**When is this updated?**  
+Updates automatically whenever the local player gains health.
+
+**Return value**
+- `object`
+  - `totalHeal` (`number`) - Amount of health gained from the most recent heal event
+  - `inferredSource`
+    - (`possiblyRegen`) or (`likelyItem`) - inferred healing source more info below
+
+**InferredHealSource**
+
+- `"possiblyRegen"` - healing likely came from regeneration (such as adrenaline)
+- `"likelyItem"` - healing likely came from an item (such as bandages)
+
+**Note**: inferred source should be treated as best guess not authoritative.
+
+**Common use cases**
+- Rendering health counters or overlays
+- health-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const heal = modAPI.getLocalPlayerHeal()
+    // example of filtering for item only heals
+    if (heal.inferredSource !== "possiblyRegen") {
+      console.log(heal.totalHeal)
+    }
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+- This hook uses inferred data sources. If you do not want those view the [getLocalPlayerHealRaw](#getlocalplayerhealraw) hook.
+
+---
 
 ### getLocalPlayerHealRaw
 
+**What does this return?**  
+Returns the *raw* heal amount the local player took.
+
+**When is this updated?**  
+Updates automatically whenever the local player regains health.
+
+**Return value**
+- `object`
+  - `totalHealRaw` (`number`) - Amount of health from the most recent heal event
+
+**Common use cases**
+- Rendering health counters or overlays
+- health-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const healthRaw = modAPI.getLocalPlayerHealRaw()
+    console.log(healthRaw.totalHealRaw)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerRemovedItem
+
+**What does this return?**  
+Returns the last removed item from the local player's inventory.
+
+**When is this updated?**  
+Updates automatically whenever the local player's inventory removes a item.
+
+**Return value**
+- `object`
+  - `removedItem` (`string`) - The name of the last removed item
+  - `removedItemAmount` (`number`) - The amount removed of the last item
+
+**Common use cases**
+- Rendering inventory counters or overlays
+- inventory-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const lastRemovedItem = modAPI.getLocalPlayerRemovedItem()
+    console.log(
+      lastRemovedItem.removedItem,
+      lastRemovedItem.removedItemAmount
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
 
 ### getLocalPlayerAddedItem
 
+**What does this return?**  
+Returns the last added item from the local player's inventory.
+
+**When is this updated?**  
+Updates automatically whenever the local player's inventory adds a item.
+
+**Return value**
+- `object`
+  - `addedItem` (`string`) - The name of the last added item
+  - `addedItemAmount` (`number`) - The amount added of the last item
+
+**Common use cases**
+- Rendering inventory counters or overlays
+- inventory-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const lastAddedItem = modAPI.getLocalPlayerAddedItem()
+    console.log(
+      lastAddedItem.addedItem,
+      lastAddedItem.addedItemAmount
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerHelmet
+
+**What does this return?**  
+Returns the current local player helmet.
+
+**When is this updated?**  
+Updates automatically whenever the local player's helmet changes.
+
+**Return value**
+- `object`
+  - `newHelmet` (`string`) - The name of the current helmet
+
+**Common use cases**
+- Rendering gear counters or overlays
+- gear-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const helmet = modAPI.getLocalPlayerHelmet()
+    console.log(helmet.newHelmet)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
 
 ### getLocalPlayerChest
 

--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -183,27 +183,322 @@ Once per game round.
 
 ## Player state hooks
 
+This section contains every on* hook related to the player.
+
 ### onLocalPlayerDeath
+
+**When does this fire?**  
+Fires once when the local player dies during a game round.
+
+**How often does it fire?**  
+Once per game round.
+
+**Common use cases**
+- Showing on screen effects
+- Setting up UI elements
+- Playing sound effects
+- Gathering data
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerDeath(() => {
+      // logic to run upon local player death
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
 
 ### onPlayerShoot
 
+**When does this fire?**  
+Fires once when *any* player owned bullet is on screen.
+
+**How often does it fire?**  
+Once per bullet spawned on screen.
+
+**Common use cases**
+- Playing sound effects
+- Bullet specific effects
+- Data gathering
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onPlayerShoot(() => {
+      // logic to run upon any bullet on screen
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is for any bullet on screen. View the [onLocalPlayerShoot](#onlocalplayershoot) hook if you want only local bullets.
+- This hook can fire frequently during active combat. Keep logic lightweight to avoid performance issues.
+
+---
+
 ### onLocalPlayerShoot
+
+**When does this fire?**  
+Fires once when any *local* player owned bullet is on screen.
+
+**How often does it fire?**  
+Once per local player owned bullet spawned on screen.
+
+**Common use cases**
+- Playing sound effects
+- Bullet specific effects
+- Data gathering
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerShoot(() => {
+      // logic to run upon any local player bullet on screen
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is for local player bullets on screen. View the [onPlayerShoot](#onplayershoot) hook if you want any bullets.
+- This hook can fire frequently during active combat. Keep logic lightweight to avoid performance issues.
+
+---
 
 ### onLocalPlayerKill
 
+**When does this fire?**  
+Fires once when the local player is credited a kill.
+
+**How often does it fire?**  
+Once per credited local player kill.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects / animations
+- Data gathering
+- Kill streak tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerKill(() => {
+      // logic to run upon local player kill
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
+
 ### onLocalPlayerHeal
+
+**When does this fire?**  
+Fires once when the local player regains health, including healing items or regeneration.
+
+**How often does it fire?**  
+Once per tick of health regained.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects / animations
+- Data gathering
+- Health tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerHeal(() => {
+      // logic to run upon local player heal
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
+
 
 ### onLocalPlayerDamage
 
+**When does this fire?**  
+Fires once when the local player takes damage.
+
+**How often does it fire?**  
+Once per tick of health lost.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects / animations
+- Data gathering
+- Health tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerDamage(() => {
+      // logic to run upon local player damage
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
+
 ### onLocalPlayerInventoryItemChange
+
+**When does this fire?**  
+Fires once when an item in the inventory of the local player changes (added, removed, or updated).
+
+**How often does it fire?**  
+Once per inventory item changed.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects / animations
+- Data gathering
+- Inventory tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerInventoryItemChange(() => {
+      // logic to run upon local player inventory item change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+
+---
 
 ### onLocalPlayerHelmetChange
 
+**When does this fire?**  
+Fires once when the local player's helmet changes (equipped, removed, or replaced).
+
+**How often does it fire?**  
+Once per helmet change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects / animations
+- Data gathering
+- Gear tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerHelmetChange(() => {
+      // logic to run upon local player helmet change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is for a single gear change. View the [onLocalPlayerGearChange](#onlocalplayergearchange) hook if you want any gear change
+
+---
+
 ### onLocalPlayerChestChange
+
+**When does this fire?**  
+Fires once when the local player’s chest changes (equipped, removed, or replaced).
+
+**How often does it fire?**  
+Once per chest change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Gear tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerChestChange(() => {
+      // logic to run upon local player chest change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is for a single gear change. View the [onLocalPlayerGearChange](#onlocalplayergearchange) hook if you want any gear change
+
+---
 
 ### onLocalPlayerBackpackChange
 
+**When does this fire?**  
+Fires once when the local player’s backpack changes (equipped, removed, or replaced).
+
+**How often does it fire?**  
+Once per backpack change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Gear tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerBackpackChange(() => {
+      // logic to run upon local player backpack change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is for a single gear change. View the [onLocalPlayerGearChange](#onlocalplayergearchange) hook if you want any gear change
+
+---
+
 ### onLocalPlayerOutfitChange
+
+**When does this fire?**  
+Fires once when the local player’s outfit changes (equipped, removed, or replaced).
+
+**How often does it fire?**  
+Once per outfit change.
+
+**Common use cases**
+- Updating UI elements
+- Playing sound effects or animations
+- Data gathering
+- Gear tracking
+
+**Example use**
+    
+    const modAPI = window.survevModAPI
+
+    modAPI.onLocalPlayerOutfitChange(() => {
+      // logic to run upon local player outfit change
+    })
+
+**Notes**
+- This hook is synchronous.
+- Execution order between multiple mods is not guaranteed.
+- This hook is for a single gear change. View the [onLocalPlayerGearChange](#onlocalplayergearchange) hook if you want any gear change
+
+---
 
 ### onLocalPlayerGearChange
 

--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -73,6 +73,9 @@ The goal of this ModAPI project is to get rid of that brittleness, within reason
     - [getLocalPlayerWeaponAmmoUsed](#getlocalplayerweaponammoused)
     - [getLocalPlayerWeaponAmmoGained](#getlocalplayerweaponammogained)
     - [getLocalPlayerWeapons](#getlocalplayerweapons)
+- [Future of the API](#future-of-the-api)
+- [Credits](#credits)
+- [Changelog](#changelog)
 
 
 # on* hooks
@@ -1018,20 +1021,428 @@ Updates automatically whenever the local player's helmet changes.
 
 ### getLocalPlayerChest
 
+**What does this return?**  
+Returns the current local player chest.
+
+**When is this updated?**  
+Updates automatically whenever the local player's chest changes.
+
+**Return value**
+- `object`
+  - `newChest` (`string`) - The name of the current chest
+
+**Common use cases**
+- Rendering gear counters or overlays
+- gear-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const chest = modAPI.getLocalPlayerChest()
+    console.log(chest.newChest)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerBackpack
+
+**What does this return?**  
+Returns the current local player backpack.
+
+**When is this updated?**  
+Updates automatically whenever the local player's backpack changes.
+
+**Return value**
+- `object`
+  - `newBackpack` (`string`) - The name of the current backpack
+
+**Common use cases**
+- Rendering gear counters or overlays
+- gear-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const backpack = modAPI.getLocalPlayerBackpack()
+    console.log(backpack.newBackpack)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
 
 ### getLocalPlayerOutfit
 
+**What does this return?**  
+Returns the current local player outfit.
+
+**When is this updated?**  
+Updates automatically whenever the local player's outfit changes.
+
+**Return value**
+- `object`
+  - `newOutfit` (`string`) - The name of the current outfit
+
+**Common use cases**
+- Rendering gear counters or overlays
+- gear-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const outfit = modAPI.getLocalPlayerOutfit()
+    console.log(outfit.newOutfit)
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerLastChangedGear
+
+**What does this return?**  
+Returns the current local player last changed gear.
+
+**When is this updated?**  
+Updates automatically whenever the local player's gear changes.
+
+**Return value**
+- `object`
+  - `gearSlot` (`string`) - The gear type
+  - `oldGear` (`string`) - The old gear
+  - `newGear` (`string`) - the current gear
+
+**Common use cases**
+- Rendering gear counters or overlays
+- gear-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const lastChangedGear = modAPI.getLocalPlayerLastChangedGear()
+    console.log(
+      lastChangedGear.gearSlot,
+      lastChangedGear.oldGear,
+      lastChangedGear.newGear
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
 
 ### getLocalPlayerGear
 
+**What does this return?**  
+Returns the current local player gear set.
+
+**When is this updated?**  
+Updates automatically whenever the local player's gear changes.
+
+**Return value**
+- `object`
+  - `helmet` (`string`) - The name of the current helmet
+  - `chest` (`string`) - The name of the current chest
+  - `backpack` (`string`) - The name of the current backpack
+  - `outfit` (`string`) - The name of the current outfit
+
+**Common use cases**
+- Rendering gear counters or overlays
+- gear-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const gearSet = modAPI.getLocalPlayerGear()
+    console.log(
+      gearSet.helmet,
+      gearSet.chest,
+      gearSet.backpack,
+      gearSet.outfit
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerCurrentEquippedWeapon
+
+**What does this return?**  
+Returns the current local player equipped weapon.
+
+**When is this updated?**  
+Updates automatically whenever the local player's equipped weapon changes.
+
+**Return value**
+- `object`
+  - `slot` (`number`) - The slot the weapon is in
+  - `weaponType` (`string`) - The weapon name
+  - `weaponAmmo` (`number`) - The amount of ammo in the weapon
+
+**slot**
+
+The number that the `slot` object returns corresponds like this:
+
+0: Primary weapon slot
+1: Secondary weapon slot
+2: Melee weapon slot
+3: Throwables
+
+**Common use cases**
+- Rendering weapon counters or overlays
+- weapon-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const currentWeapon = modAPI.getLocalPlayerCurrentEquippedWeapon()
+    console.log(
+      currentWeapon.slot,
+      currentWeapon.weaponType,
+      currentWeapon.weaponAmmo
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
 
 ### getLocalPlayerLastChangedWeapon
 
+**What does this return?**  
+Returns the last changed local player weapon.
+
+**When is this updated?**  
+Updates automatically whenever the local player's weapon changes.
+
+**Return value**
+- `object`
+  - `slot` (`number`) - The slot the weapon is in
+  - `oldWeapon` (`string`) - The old weapon
+  - `newWeapon` (`number`) - The new replacement weapon
+
+**slot**
+
+The number that the `slot` object returns corresponds like this:
+
+0: Primary weapon slot
+1: Secondary weapon slot
+2: Melee weapon slot
+3: Throwables
+
+**Common use cases**
+- Rendering weapon counters or overlays
+- weapon-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const lastChangedWeapon = modAPI.getLocalPlayerLastChangedWeapon()
+    console.log(
+      lastChangedWeapon.slot,
+      lastChangedWeapon.oldWeapon,
+      lastChangedWeapon.newWeapon
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerWeaponAmmoUsed
+
+**What does this return?**  
+Returns the last ammo used delta of the local player weapon.
+
+**When is this updated?**  
+Updates automatically whenever the local player's weapon ammo delta changes.
+
+**Return value**
+- `object`
+  - `slot` (`number`) - The slot the weapon is in
+  - `weaponType` (`string`) - The weapon name
+  - `weaponAmmo` (`number`) - The amount of ammo in the weapon
+  - `ammoUsed` (`number`) - The delta of the amount of used ammo
+
+**slot**
+
+The number that the `slot` object returns corresponds like this:
+
+0: Primary weapon slot
+1: Secondary weapon slot
+2: Melee weapon slot
+3: Throwables
+
+**Common use cases**
+- Rendering weapon counters or overlays
+- weapon-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const weaponAmmoUsed = modAPI.getLocalPlayerWeaponAmmoUsed()
+    console.log(
+      weaponAmmoUsed.slot,
+      weaponAmmoUsed.weaponType,
+      weaponAmmoUsed.weaponAmmo,
+      weaponAmmoUsed.ammoUsed
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
 
 ### getLocalPlayerWeaponAmmoGained
 
+**What does this return?**  
+Returns the last ammo gained delta of the local player weapon.
+
+**When is this updated?**  
+Updates automatically whenever the local player's equipped weapon ammo delta changes.
+
+**Return value**
+- `object`
+  - `slot` (`number`) - The slot the weapon is in
+  - `weaponType` (`string`) - The weapon name
+  - `weaponAmmo` (`number`) - The amount of ammo in the weapon
+  - `ammoGained` (`number`) - The delta of the amount of gained ammo
+
+**slot**
+
+The number that the `slot` object returns corresponds like this:
+
+0: Primary weapon slot
+1: Secondary weapon slot
+2: Melee weapon slot
+3: Throwables
+
+**Common use cases**
+- Rendering weapon counters or overlays
+- weapon-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const weaponAmmoGained = modAPI.getLocalPlayerWeaponAmmoGained()
+    console.log(
+      weaponAmmoGained.slot,
+      weaponAmmoGained.weaponType,
+      weaponAmmoGained.weaponAmmo,
+      weaponAmmoGained.ammoGained
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
 ### getLocalPlayerWeapons
+
+**What does this return?**  
+Returns the weapon set of the local player.
+
+**When is this updated?**  
+Updates automatically whenever the local player's weapons change.
+
+**Return value**
+- `object`
+  - `primaryWeaponType` (`string`) - The primary weapon name
+  - `primaryWeaponAmmo` (`string`) - The primary weapon ammo
+  - `secondaryWeaponType` (`string`) - The secondary weapon name
+  - `secondaryWeaponAmmo` (`string`) - The secondary weapon ammo
+  - `meleeWeaponType` (`string`) - The melee weapon name
+  - `meleeWeaponAmmo` (`string`) - The melee weapon ammo
+  - `throwableWeaponType` (`string`) - The throwable weapon name
+  - `throwableWeaponAmmo` (`string`) - The throwable weapon ammo
+
+**Common use cases**
+- Rendering weapon counters or overlays
+- weapon-based logic or alerts
+- Debugging or analytics
+
+**Example use**
+
+    const modAPI = window.survevModAPI
+
+    const weaponSet = modAPI.getLocalPlayerWeapons()
+    console.log(
+      weaponSet.primaryWeaponType,
+      weaponSet.primaryWeaponAmmo,
+      weaponSet.secondaryWeaponType,
+      weaponSet.secondaryWeaponAmmo,
+      weaponSet.meleeWeaponType,
+      weaponSet.meleeWeaponAmmo,
+      weaponSet.throwableWeaponType,
+      weaponSet.throwableWeaponAmmo,
+    )
+
+**Notes**
+- This hook is synchronous.
+- Returned values are read-only.
+
+---
+
+# Future of the API
+
+This API is not final. It is meant to be shaped by *you* yes, *you*, the modder.
+
+If you find yourself thinking things like:
+
+- "There should really be an on* hook for this"
+- "This get* hook works, but it's akward to use"
+
+or anything else reasonable, please speak up.
+
+This API is intentionally conservative, but it can’t evolve in the right direction without feedback from the people actually building mods with it.
+
+# Credits
+
+- [chickenPoo](https://github.com/chickenpoo351)
+  - Original API system implementation
+  - Original API documentation
+
+More contributors to be added as the API evolves.
+
+# Changelog
+
+## survevModAPI V1.0
+
+### Features
+
+- Initial on* and get* hooks added
+- Initial documentation
+
+### Contributors
+
+- [chickenPoo](https://github.com/chickenpoo351)

--- a/MOD_API_DOCS.md
+++ b/MOD_API_DOCS.md
@@ -745,7 +745,7 @@ If you need timing, historical data collection, or event context, combine get* h
     const modAPI = window.survevModAPI
 
     modAPI.onLocalPlayerDamage(() => {
-      const newHealth = getLocalPlayerHealth();
+      const newHealth = modAPI.getLocalPlayerHealth();
       // now do whatever you like with that info
     })
 

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -85,7 +85,7 @@ declare global {
     window.fusetag = window.fusetag || (window.fusetag = { que: [] });
 
     interface Window {
-        __MYGAME_MOD_API__?: ModAPI;
+        survevModAPI?: ModAPI;
     }
 }
 

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -16,10 +16,10 @@ declare global {
                 | JQuery.htmlString
                 | JQuery.Node
                 | ((
-                    this: TElement,
-                    index: number,
-                    oldhtml: JQuery.htmlString,
-                ) => JQuery.htmlString | JQuery.Node),
+                      this: TElement,
+                      index: number,
+                      oldhtml: JQuery.htmlString,
+                  ) => JQuery.htmlString | JQuery.Node),
         ): this;
     }
 
@@ -87,7 +87,6 @@ declare global {
     interface Window {
         __MYGAME_MOD_API__?: ModAPI;
     }
-
 }
 
 declare module "pixi.js-legacy" {
@@ -97,4 +96,4 @@ declare module "pixi.js-legacy" {
         __layerIdx: number;
     }
 }
-export { };
+export {};

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -1,3 +1,5 @@
+import type { ModAPI } from "./modding/ModAPI";
+
 /// <reference types="vite/client" />
 /// <reference types="turnstile-types" />
 
@@ -14,10 +16,10 @@ declare global {
                 | JQuery.htmlString
                 | JQuery.Node
                 | ((
-                      this: TElement,
-                      index: number,
-                      oldhtml: JQuery.htmlString,
-                  ) => JQuery.htmlString | JQuery.Node),
+                    this: TElement,
+                    index: number,
+                    oldhtml: JQuery.htmlString,
+                ) => JQuery.htmlString | JQuery.Node),
         ): this;
     }
 
@@ -81,6 +83,11 @@ declare global {
     const TURNSTILE_SITE_KEY: string | undefined;
 
     window.fusetag = window.fusetag || (window.fusetag = { que: [] });
+
+    interface Window {
+        __MYGAME_MOD_API__?: ModAPI;
+    }
+
 }
 
 declare module "pixi.js-legacy" {
@@ -90,4 +97,4 @@ declare module "pixi.js-legacy" {
         __layerIdx: number;
     }
 }
-export {};
+export { };

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -1,4 +1,4 @@
-import type { ModAPI } from "./src/modding/Loader";
+import type { ModAPI } from "./src/modding/ModAPI";
 
 /// <reference types="vite/client" />
 /// <reference types="turnstile-types" />

--- a/client/global.d.ts
+++ b/client/global.d.ts
@@ -1,4 +1,4 @@
-import type { ModAPI } from "./modding/ModAPI";
+import type { ModAPI } from "./src/modding/Loader";
 
 /// <reference types="vite/client" />
 /// <reference types="turnstile-types" />

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -355,7 +355,7 @@ export class Game {
         this.m_camera.m_setRotationEnabled(this.m_config.get("localRotation")!);
         this.m_playerBarn.anonPlayerNames = this.m_config.get("anonPlayerNames")!;
         this.initialized = true;
-        modAPI._emitGameStart();
+        modAPI._emit("gameStart", undefined);
     }
 
     free() {
@@ -368,7 +368,7 @@ export class Game {
         this.connected = false;
         if (this.initialized) {
             this.initialized = false;
-            modAPI._emitGameEnd();
+            modAPI._emit("gameEnd", undefined);
             this.m_updatePass = false;
             this.m_updatePassDelay = 0;
             this.m_emoteBarn.m_free();
@@ -1402,7 +1402,7 @@ export class Game {
                     // modAPI.getPlayerKills() then it might be undefined when emit fires I think...
                     // either way cant hurt I guess
                     modAPI._setPlayerKills(msg.killerKills);
-                    modAPI._emitLocalPlayerKill();
+                    modAPI._emit("localPlayerKill", undefined);
                 }
 
                 // Add killfeed entry for this kill

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -1402,7 +1402,7 @@ export class Game {
                     // modAPI.getPlayerKills() then it might be undefined when emit fires I think...
                     // either way cant hurt I guess
                     modAPI._setPlayerKills(msg.killerKills);
-                    modAPI._emitPlayerKill();
+                    modAPI._emitLocalPlayerKill();
                 }
 
                 // Add killfeed entry for this kill

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -368,6 +368,7 @@ export class Game {
         this.connected = false;
         if (this.initialized) {
             this.initialized = false;
+            modAPI._emitGameEnd();
             this.m_updatePass = false;
             this.m_updatePassDelay = 0;
             this.m_emoteBarn.m_free();

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -25,6 +25,7 @@ import { type InputHandler, Key } from "./input";
 import type { InputBinds, InputBindUi } from "./inputBinds";
 import type { SoundHandle } from "./lib/createJS";
 import { Map } from "./map";
+import { modAPI } from "./modding/ModAPIInstance";
 import { AirdropBarn } from "./objects/airdrop";
 import { BulletBarn, createBullet } from "./objects/bullet";
 import { DeadBodyBarn } from "./objects/deadBody";
@@ -46,7 +47,6 @@ import type { Localization } from "./ui/localization";
 import { Touch } from "./ui/touch";
 import { UiManager } from "./ui/ui";
 import { UiManager2 } from "./ui/ui2";
-import { modAPI } from "./modding/ModAPIInstance"
 
 export interface Ctx {
     audioManager: AudioManager;
@@ -1397,6 +1397,12 @@ export class Game {
                 // Update local kill counter
                 if (msg.killCreditId == this.m_localId && msg.killed) {
                     this.m_uiManager.setLocalKills(msg.killerKills);
+                    // I think thats the order they should be in... because if emit
+                    // is updated first and right after that someone calls
+                    // modAPI.getPlayerKills() then it might be undefined when emit fires I think...
+                    // either way cant hurt I guess
+                    modAPI._setPlayerKills(msg.killerKills);
+                    modAPI._emitPlayerKill();
                 }
 
                 // Add killfeed entry for this kill

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -1401,7 +1401,7 @@ export class Game {
                     // is updated first and right after that someone calls
                     // modAPI.getPlayerKills() then it might be undefined when emit fires I think...
                     // either way cant hurt I guess
-                    modAPI._setPlayerKills(msg.killerKills);
+                    modAPI._setLocalPlayerKills({ totalKills: msg.killerKills });
                     modAPI._emit("localPlayerKill", undefined);
                 }
 

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -46,6 +46,7 @@ import type { Localization } from "./ui/localization";
 import { Touch } from "./ui/touch";
 import { UiManager } from "./ui/ui";
 import { UiManager2 } from "./ui/ui2";
+import { modAPI } from "./modding/ModAPIInstance"
 
 export interface Ctx {
     audioManager: AudioManager;
@@ -354,6 +355,7 @@ export class Game {
         this.m_camera.m_setRotationEnabled(this.m_config.get("localRotation")!);
         this.m_playerBarn.anonPlayerNames = this.m_config.get("anonPlayerNames")!;
         this.initialized = true;
+        modAPI._emitGameStart();
     }
 
     free() {

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -34,6 +34,7 @@ import { Pass } from "./ui/pass";
 import { ProfileUi } from "./ui/profileUi";
 import { TeamMenu } from "./ui/teamMenu";
 import { loadStaticDomImages } from "./ui/ui2";
+import "./modding/Loader";
 
 export class Application {
     nameInput = $("#player-name-input-solo");

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -1,18 +1,9 @@
-import { createModAPI } from "./ModAPI";
+import { modAPI } from "./ModAPIInstance";
+// I dont think I made this clear before but this file is essentially just dev testing so you can
+// put like "fake mods" in here just to make sure the code works
 
 // STRIP_FROM_PROD_CLIENT:START
-const modAPI = createModAPI();
 
-window.__MYGAME_MOD_API__ = modAPI;
-
-// eventually replace fakeGameStart with well the actual game starting
-const fakeGameStart = () => {
-  console.log("Game starting...");
-  modAPI._emitGameStart();
-};
-
-// simulate game start after 1 second (for testing)
-setTimeout(fakeGameStart, 1000);
 
 // example of replacing a local player texture
 modAPI.setLocalPlayerTexture("playerSkin", "/textures/test-skin.png");

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -20,4 +20,8 @@ modAPI.onGameEnd(() => {
 modAPI.onPlayerDeath(() => {
   console.log("onPlayerDeath ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures())
 })
+
+modAPI.onPlayerShoot(() => {
+  console.log("onPlayerShoot ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures())
+})
 // STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -4,36 +4,27 @@ import { modAPI } from "./ModAPIInstance";
 // put like "fake mods" in here just to make sure the code works
 
 // STRIP_FROM_PROD_CLIENT:START
-
-// example of replacing a local player texture
-modAPI.setLocalPlayerTexture("playerSkin", "/textures/test-skin.png");
-
-// and then using that here when GameStart fires pretty simple right?
 modAPI.onGameStart(() => {
     console.log(
-        "onGameStart ModAPI hook fired! Current textures:",
-        modAPI.getLocalPlayerTextures(),
+        "onGameStart ModAPI hook fired!"
     );
 });
 
 modAPI.onGameEnd(() => {
     console.log(
-        "onGameEnd ModAPI hook fired! Current textures:",
-        modAPI.getLocalPlayerTextures(),
+        "onGameEnd ModAPI hook fired!"
     );
 });
 
-modAPI.onPlayerDeath(() => {
+modAPI.onLocalPlayerDeath(() => {
     console.log(
-        "onPlayerDeath ModAPI hook fired! Current textures:",
-        modAPI.getLocalPlayerTextures(),
+        "onLocalPlayerDeath ModAPI hook fired!"
     );
 });
 
 modAPI.onPlayerShoot(() => {
     console.log(
-        "onPlayerShoot ModAPI hook fired! Current textures:",
-        modAPI.getLocalPlayerTextures(),
+        "onPlayerShoot ModAPI hook fired!"
     );
 });
 
@@ -45,8 +36,8 @@ modAPI.onLocalPlayerShoot(() => {
 // also im gonna stop adding the modAPI.getLocalPlayerTextures because well too much typing...
 // but it will make a return once I actually hook it up
 
-modAPI.onPlayerKill(() => {
-    console.log("onPlayerKill ModAPI hook fired");
+modAPI.onLocalPlayerKill(() => {
+    console.log("onLocalPlayerKill ModAPI hook fired");
     const totalKills = modAPI.getPlayerKills();
     console.log("getPlayerKills ModAPI hook reported:", totalKills.totalKills, "as the kill amount");
 });

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -16,4 +16,8 @@ modAPI.onGameStart(() => {
 modAPI.onGameEnd(() => {
   console.log("onGameEnd ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures());
 })
+
+modAPI.onPlayerDeath(() => {
+  console.log("onPlayerDeath ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures())
+})
 // STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -1,0 +1,24 @@
+import { createModAPI } from "./ModAPI";
+
+// STRIP_FROM_PROD_CLIENT:START
+const modAPI = createModAPI();
+
+window.__MYGAME_MOD_API__ = modAPI;
+
+// eventually replace fakeGameStart with well the actual game starting
+const fakeGameStart = () => {
+  console.log("Game starting...");
+  modAPI._emitGameStart();
+};
+
+// simulate game start after 1 second (for testing)
+setTimeout(fakeGameStart, 1000);
+
+// example of replacing a local player texture
+modAPI.setLocalPlayerTexture("playerSkin", "/textures/test-skin.png");
+
+// and then using that here when GameStart fires pretty simple right?
+modAPI.onGameStart(() => {
+  console.log("ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures());
+});
+// STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -5,27 +5,19 @@ import { modAPI } from "./ModAPIInstance";
 
 // STRIP_FROM_PROD_CLIENT:START
 modAPI.onGameStart(() => {
-    console.log(
-        "onGameStart ModAPI hook fired!"
-    );
+    console.log("onGameStart ModAPI hook fired!");
 });
 
 modAPI.onGameEnd(() => {
-    console.log(
-        "onGameEnd ModAPI hook fired!"
-    );
+    console.log("onGameEnd ModAPI hook fired!");
 });
 
 modAPI.onLocalPlayerDeath(() => {
-    console.log(
-        "onLocalPlayerDeath ModAPI hook fired!"
-    );
+    console.log("onLocalPlayerDeath ModAPI hook fired!");
 });
 
 modAPI.onPlayerShoot(() => {
-    console.log(
-        "onPlayerShoot ModAPI hook fired!"
-    );
+    console.log("onPlayerShoot ModAPI hook fired!");
 });
 
 modAPI.onLocalPlayerShoot(() => {
@@ -39,7 +31,11 @@ modAPI.onLocalPlayerShoot(() => {
 modAPI.onLocalPlayerKill(() => {
     console.log("onLocalPlayerKill ModAPI hook fired");
     const totalKills = modAPI.getPlayerKills();
-    console.log("getPlayerKills ModAPI hook reported:", totalKills.totalKills, "as the kill amount");
+    console.log(
+        "getPlayerKills ModAPI hook reported:",
+        totalKills.totalKills,
+        "as the kill amount",
+    );
 });
 
 modAPI.onLocalPlayerHeal(() => {
@@ -49,9 +45,17 @@ modAPI.onLocalPlayerHeal(() => {
     // I should probably put this console.log behind a if statement checking
     // if inferredSource !== "possiblyRegen" because as is it produces a lot of console spam...
     // but eh I guess its fine it is just for testing after all :o
-    console.log("getLocalPlayerHealth ModAPI hook reported:", newPlayerHealth, "as the new health amount");
+    console.log(
+        "getLocalPlayerHealth ModAPI hook reported:",
+        newPlayerHealth,
+        "as the new health amount",
+    );
     if (playerHealAmount.inferredSource !== "possiblyRegen") {
-        console.log("getLocalPlayerHeal ModAPI hook reported:", playerHealAmount.totalHeal, "as the amount of non regen health replenished");
+        console.log(
+            "getLocalPlayerHeal ModAPI hook reported:",
+            playerHealAmount.totalHeal,
+            "as the amount of non regen health replenished",
+        );
     }
 });
 
@@ -59,32 +63,56 @@ modAPI.onLocalPlayerDamage(() => {
     console.log("onLocalPlayerDamage ModAPI hook fired!");
     const newPlayerHealth = modAPI.getLocalPlayerHealth();
     const playerDamageTaken = modAPI.getLocalPlayerDamage();
-    console.log("getLocalPlayerHealth ModAPI hook reported:", newPlayerHealth, "as the new health amount");
-    console.log("getLocalPlayerDamage ModAPI hook reported:", playerDamageTaken.totalDamage, "as the damage taken");
+    console.log(
+        "getLocalPlayerHealth ModAPI hook reported:",
+        newPlayerHealth,
+        "as the new health amount",
+    );
+    console.log(
+        "getLocalPlayerDamage ModAPI hook reported:",
+        playerDamageTaken.totalDamage,
+        "as the damage taken",
+    );
 });
 
 // lots of testing time...
 modAPI.onLocalPlayerRemovedItem(() => {
     console.log("onLocalPlayerRemovedItem ModAPI hook fired!");
     const removedItem = modAPI.getLocalPlayerRemovedItem();
-    console.log("getLocalPlayerRemovedItem ModAPI hooke reported:", removedItem, "as the removed item");
+    console.log(
+        "getLocalPlayerRemovedItem ModAPI hooke reported:",
+        removedItem,
+        "as the removed item",
+    );
 });
 
 modAPI.onLocalPlayerAddedItem(() => {
     console.log("onLocalPlayerAddedItem ModAPI hook fired!");
     const addedItem = modAPI.getLocalPlayerAddedItem();
-    console.log("getLocalPlayerAddedItem ModAPI hook reported:", addedItem, "as the added item");
+    console.log(
+        "getLocalPlayerAddedItem ModAPI hook reported:",
+        addedItem,
+        "as the added item",
+    );
 });
 
 modAPI.onLocalPlayerGearChange(() => {
     console.log("onLocalPlayerGearChange ModAPI hook fired!");
     const playerGear = modAPI.getLocalPlayerGear();
-    console.log("getLocalPlayerGear ModAPi hook reported:", playerGear, "as the current player gear");
+    console.log(
+        "getLocalPlayerGear ModAPi hook reported:",
+        playerGear,
+        "as the current player gear",
+    );
 });
 
 modAPI.onLocalPlayerWeaponChange(() => {
     console.log("onLocalPlayerWeaponChange ModAPI hook fired!");
     const equippedWeapons = modAPI.getLocalPlayerWeapons();
-    console.log("getLocalPlayerWeapons ModAPI hook reported:", equippedWeapons, "as the equipped weapons");
+    console.log(
+        "getLocalPlayerWeapons ModAPI hook reported:",
+        equippedWeapons,
+        "as the equipped weapons",
+    );
 });
 // STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -4,23 +4,24 @@ import { modAPI } from "./ModAPIInstance";
 // put like "fake mods" in here just to make sure the code works
 
 // STRIP_FROM_PROD_CLIENT:START
+
 modAPI.onGameStart(() => {
-    console.log("onGameStart ModAPI hook fired!");
+    console.log("the real onGameStart ModAPI hook fired!");
 });
 
-modAPI.onGameEnd(() => {
+modAPI.on("gameEnd", () => {
     console.log("onGameEnd ModAPI hook fired!");
 });
 
-modAPI.onLocalPlayerDeath(() => {
+modAPI.on("localPlayerDeath", () => {
     console.log("onLocalPlayerDeath ModAPI hook fired!");
 });
 
-modAPI.onPlayerShoot(() => {
+modAPI.on("playerShoot", () => {
     console.log("onPlayerShoot ModAPI hook fired!");
 });
 
-modAPI.onLocalPlayerShoot(() => {
+modAPI.on("localPlayerShoot", () => {
     console.log("onLocalPlayerShoot ModAPI hook fired!");
 });
 
@@ -28,7 +29,7 @@ modAPI.onLocalPlayerShoot(() => {
 // also im gonna stop adding the modAPI.getLocalPlayerTextures because well too much typing...
 // but it will make a return once I actually hook it up
 
-modAPI.onLocalPlayerKill(() => {
+modAPI.on("localPlayerKill", () => {
     console.log("onLocalPlayerKill ModAPI hook fired");
     const totalKills = modAPI.getLocalPlayerKills();
     console.log(
@@ -38,7 +39,7 @@ modAPI.onLocalPlayerKill(() => {
     );
 });
 
-modAPI.onLocalPlayerHeal(() => {
+modAPI.on("localPlayerHeal", () => {
     console.log("onLocalPlayerHeal ModAPI hook fired!");
     const newPlayerHealth = modAPI.getLocalPlayerHealth();
     const playerHealAmount = modAPI.getLocalPlayerHeal();
@@ -59,7 +60,7 @@ modAPI.onLocalPlayerHeal(() => {
     }
 });
 
-modAPI.onLocalPlayerDamage(() => {
+modAPI.on("localPlayerDamage", () => {
     console.log("onLocalPlayerDamage ModAPI hook fired!");
     const newPlayerHealth = modAPI.getLocalPlayerHealth();
     const playerDamageTaken = modAPI.getLocalPlayerDamage();
@@ -76,7 +77,7 @@ modAPI.onLocalPlayerDamage(() => {
 });
 
 // lots of testing time...
-modAPI.onLocalPlayerRemovedItem(() => {
+modAPI.on("localPlayerRemovedItem", () => {
     console.log("onLocalPlayerRemovedItem ModAPI hook fired!");
     const removedItem = modAPI.getLocalPlayerRemovedItem();
     console.log(
@@ -86,7 +87,7 @@ modAPI.onLocalPlayerRemovedItem(() => {
     );
 });
 
-modAPI.onLocalPlayerAddedItem(() => {
+modAPI.on("localPlayerAddedItem", () => {
     console.log("onLocalPlayerAddedItem ModAPI hook fired!");
     const addedItem = modAPI.getLocalPlayerAddedItem();
     console.log(
@@ -96,7 +97,7 @@ modAPI.onLocalPlayerAddedItem(() => {
     );
 });
 
-modAPI.onLocalPlayerGearChange(() => {
+modAPI.on("localPlayerGearChange", () => {
     console.log("onLocalPlayerGearChange ModAPI hook fired!");
     const playerGear = modAPI.getLocalPlayerGear();
     console.log(
@@ -106,7 +107,7 @@ modAPI.onLocalPlayerGearChange(() => {
     );
 });
 
-modAPI.onLocalPlayerWeaponChange(() => {
+modAPI.on("localPlayerWeaponChange", () => {
     console.log("onLocalPlayerWeaponChange ModAPI hook fired!");
     const equippedWeapons = modAPI.getLocalPlayerWeapons();
     console.log(

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -70,5 +70,30 @@ modAPI.onLocalPlayerDamage(() => {
     const playerDamageTaken = modAPI.getLocalPlayerDamage();
     console.log("getLocalPlayerHealth ModAPI hook reported:", newPlayerHealth, "as the new health amount");
     console.log("getLocalPlayerDamage ModAPI hook reported:", playerDamageTaken.totalDamage, "as the damage taken");
-})
+});
+
+// lots of testing time...
+modAPI.onLocalPlayerRemovedItem(() => {
+    console.log("onLocalPlayerRemovedItem ModAPI hook fired!");
+    const removedItem = modAPI.getLocalPlayerRemovedItem();
+    console.log("getLocalPlayerRemovedItem ModAPI hooke reported:", removedItem, "as the removed item");
+});
+
+modAPI.onLocalPlayerAddedItem(() => {
+    console.log("onLocalPlayerAddedItem ModAPI hook fired!");
+    const addedItem = modAPI.getLocalPlayerAddedItem();
+    console.log("getLocalPlayerAddedItem ModAPI hook reported:", addedItem, "as the added item");
+});
+
+modAPI.onLocalPlayerGearChange(() => {
+    console.log("onLocalPlayerGearChange ModAPI hook fired!");
+    const playerGear = modAPI.getLocalPlayerGear();
+    console.log("getLocalPlayerGear ModAPi hook reported:", playerGear, "as the current player gear");
+});
+
+modAPI.onLocalPlayerWeaponChange(() => {
+    console.log("onLocalPlayerWeaponChange ModAPI hook fired!");
+    const equippedWeapons = modAPI.getLocalPlayerWeapons();
+    console.log("getLocalPlayerWeapons ModAPI hook reported:", equippedWeapons, "as the equipped weapons");
+});
 // STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -1,27 +1,54 @@
 import { modAPI } from "./ModAPIInstance";
+
 // I dont think I made this clear before but this file is essentially just dev testing so you can
 // put like "fake mods" in here just to make sure the code works
 
 // STRIP_FROM_PROD_CLIENT:START
-
 
 // example of replacing a local player texture
 modAPI.setLocalPlayerTexture("playerSkin", "/textures/test-skin.png");
 
 // and then using that here when GameStart fires pretty simple right?
 modAPI.onGameStart(() => {
-  console.log("onGameStart ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures());
+    console.log(
+        "onGameStart ModAPI hook fired! Current textures:",
+        modAPI.getLocalPlayerTextures(),
+    );
 });
 
 modAPI.onGameEnd(() => {
-  console.log("onGameEnd ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures());
-})
+    console.log(
+        "onGameEnd ModAPI hook fired! Current textures:",
+        modAPI.getLocalPlayerTextures(),
+    );
+});
 
 modAPI.onPlayerDeath(() => {
-  console.log("onPlayerDeath ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures())
-})
+    console.log(
+        "onPlayerDeath ModAPI hook fired! Current textures:",
+        modAPI.getLocalPlayerTextures(),
+    );
+});
 
 modAPI.onPlayerShoot(() => {
-  console.log("onPlayerShoot ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures())
-})
+    console.log(
+        "onPlayerShoot ModAPI hook fired! Current textures:",
+        modAPI.getLocalPlayerTextures(),
+    );
+});
+
+modAPI.onLocalPlayerShoot(() => {
+    console.log("onLocalPlayerShoot ModAPI hook fired!");
+});
+
+// I guess I can test these 2 at the same time... makes sense to me
+// also im gonna stop adding the modAPI.getLocalPlayerTextures because well too much typing...
+// but it will make a return once I actually hook it up
+
+modAPI.onPlayerKill(() => {
+    console.log("onPlayerKill ModAPI hook fired");
+    const totalKills = modAPI.getPlayerKills();
+    console.log("getPlayerKills ModAPI hook reported:", totalKills, "as the kill amount");
+});
+
 // STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -48,7 +48,27 @@ modAPI.onLocalPlayerShoot(() => {
 modAPI.onPlayerKill(() => {
     console.log("onPlayerKill ModAPI hook fired");
     const totalKills = modAPI.getPlayerKills();
-    console.log("getPlayerKills ModAPI hook reported:", totalKills, "as the kill amount");
+    console.log("getPlayerKills ModAPI hook reported:", totalKills.totalKills, "as the kill amount");
 });
 
+modAPI.onLocalPlayerHeal(() => {
+    console.log("onLocalPlayerHeal ModAPI hook fired!");
+    const newPlayerHealth = modAPI.getLocalPlayerHealth();
+    const playerHealAmount = modAPI.getLocalPlayerHeal();
+    // I should probably put this console.log behind a if statement checking
+    // if inferredSource !== "possiblyRegen" because as is it produces a lot of console spam...
+    // but eh I guess its fine it is just for testing after all :o
+    console.log("getLocalPlayerHealth ModAPI hook reported:", newPlayerHealth, "as the new health amount");
+    if (playerHealAmount.inferredSource !== "possiblyRegen") {
+        console.log("getLocalPlayerHeal ModAPI hook reported:", playerHealAmount.totalHeal, "as the amount of non regen health replenished");
+    }
+});
+
+modAPI.onLocalPlayerDamage(() => {
+    console.log("onLocalPlayerDamage ModAPI hook fired!");
+    const newPlayerHealth = modAPI.getLocalPlayerHealth();
+    const playerDamageTaken = modAPI.getLocalPlayerDamage();
+    console.log("getLocalPlayerHealth ModAPI hook reported:", newPlayerHealth, "as the new health amount");
+    console.log("getLocalPlayerDamage ModAPI hook reported:", playerDamageTaken.totalDamage, "as the damage taken");
+})
 // STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -10,6 +10,10 @@ modAPI.setLocalPlayerTexture("playerSkin", "/textures/test-skin.png");
 
 // and then using that here when GameStart fires pretty simple right?
 modAPI.onGameStart(() => {
-  console.log("ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures());
+  console.log("onGameStart ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures());
 });
+
+modAPI.onGameEnd(() => {
+  console.log("onGameEnd ModAPI hook fired! Current textures:", modAPI.getLocalPlayerTextures());
+})
 // STRIP_FROM_PROD_CLIENT:END

--- a/client/src/modding/Loader.ts
+++ b/client/src/modding/Loader.ts
@@ -30,7 +30,7 @@ modAPI.onLocalPlayerShoot(() => {
 
 modAPI.onLocalPlayerKill(() => {
     console.log("onLocalPlayerKill ModAPI hook fired");
-    const totalKills = modAPI.getPlayerKills();
+    const totalKills = modAPI.getLocalPlayerKills();
     console.log(
         "getPlayerKills ModAPI hook reported:",
         totalKills.totalKills,

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -1,0 +1,39 @@
+type GameStartListener = () => void;
+
+export interface TextureOverrides {
+  [key: string]: string; // key = texture ID, value = URL/path
+}
+
+export function createModAPI() {
+  const gameStartListeners: GameStartListener[] = [];
+  const textureOverrides: TextureOverrides = {};
+
+  return Object.freeze({
+
+    onGameStart(fn: GameStartListener) {
+      gameStartListeners.push(fn);
+    },
+
+    /**
+     * @param textureId string ID of the texture
+     * @param url path/URL to the texture
+     */
+    setLocalPlayerTexture(textureId: string, url: string) {
+      textureOverrides[textureId] = url;
+    },
+
+    getLocalPlayerTextures(): Readonly<TextureOverrides> {
+      return { ...textureOverrides };
+    },
+
+    _emitGameStart() {
+      for (const fn of gameStartListeners) fn();
+    },
+
+    _getTextureOverrides() {
+      return textureOverrides;
+    },
+  });
+}
+
+export type ModAPI = ReturnType<typeof createModAPI>;

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -1,26 +1,29 @@
-type OnEventMap = {
-    gameStart: void;
-    gameEnd: void;
-    localPlayerDeath: void;
-    playerShoot: void;
-    localPlayerShoot: void;
-    localPlayerKill: void;
-    localPlayerHeal: void;
-    localPlayerDamage: void;
-    localPlayerInventoryItemChange: void;
-    localPlayerHelmetChange: void;
-    localPlayerChestChange: void;
-    localPlayerBackpackChange: void;
-    localPlayerOutfitChange: void;
-    localPlayerGearChange: void;
-    localPlayerEquippedWeaponChange: void;
-    localPlayerWeaponChange: void;
-    localPlayerWeaponAmmoUsed: void;
-    localPlayerWeaponAmmoGained: void;
-    localPlayerRemovedItem: void;
-    localPlayerAddedItem: void;
-};
+// so turns out you can do the generation from one map thingy if you
+// use a const instead of type which is cool!
+const eventMap = {
+    gameStart: undefined,
+    gameEnd: undefined,
+    localPlayerDeath: undefined,
+    playerShoot: undefined,
+    localPlayerShoot: undefined,
+    localPlayerKill: undefined,
+    localPlayerHeal: undefined,
+    localPlayerDamage: undefined,
+    localPlayerInventoryItemChange: undefined,
+    localPlayerHelmetChange: undefined,
+    localPlayerChestChange: undefined,
+    localPlayerBackpackChange: undefined,
+    localPlayerOutfitChange: undefined,
+    localPlayerGearChange: undefined,
+    localPlayerEquippedWeaponChange: undefined,
+    localPlayerWeaponChange: undefined,
+    localPlayerWeaponAmmoUsed: undefined,
+    localPlayerWeaponAmmoGained: undefined,
+    localPlayerRemovedItem: undefined,
+    localPlayerAddedItem: undefined,
+} as const;
 
+type OnEventMap = typeof eventMap;
 type ModEvent = keyof OnEventMap;
 
 type ModEventCallback<E extends ModEvent> = OnEventMap[E] extends void
@@ -31,142 +34,86 @@ type EventHooks = {
     [E in ModEvent as `on${Capitalize<E>}`]: (cb: ModEventCallback<E>) => void;
 };
 
-// yes you do have to repeat the on* hook names here but I mean
-// considering that thats all thats needed to you know have both the
-// on("gameStart", () => {}) and onGameStart(() => {}) styles I would say thats fine
-// considering well docs are easier to write and some people prefer one or the other :p
+const infoMap = {
+    localPlayerKills: { totalKills: 0 },
+    localPlayerHealth: { totalHealth: 100 },
+    localPlayerDamage: { totalDamage: 0 },
+    localPlayerHeal: {
+        totalHeal: 0,
+        inferredSource: undefined as "possiblyRegen" | "likelyItem" | undefined, // I think thats right?
+    },
+    localPlayerHealRaw: { totalHealRaw: 0 },
+    localPlayerAddedItem: {
+        addedItem: "",
+        addedItemAmount: 0,
+    },
+    localPlayerRemovedItem: {
+        removedItem: "",
+        removedItemAmount: 0,
+    },
+    localPlayerHelmet: { newHelmet: "" },
+    localPlayerChest: { newChest: "" },
+    localPlayerBackpack: { newBackpack: "" },
+    localPlayerOutfit: { newOutfit: "" },
+    localPlayerLastChangedGear: {
+        gearSlot: "",
+        oldGear: "",
+        newGear: "",
+    },
+    localPlayerGear: {
+        helmet: "",
+        chest: "",
+        backpack: "",
+        outfit: "",
+    },
+    localPlayerCurrentEquippedWeapon: {
+        slot: 0,
+        weaponType: "",
+        weaponAmmo: 0,
+    },
+    localPlayerLastChangedWeapon: {
+        slot: 0,
+        oldWeapon: "",
+        newWeapon: "",
+    },
+    localPlayerWeaponAmmoUsed: {
+        slot: 0,
+        weaponType: "",
+        weaponAmmo: 0,
+        ammoUsed: 0,
+    },
+    localPlayerWeaponAmmoGained: {
+        slot: 0,
+        weaponType: "",
+        weaponAmmo: 0,
+        ammoGained: 0,
+    },
+    localPlayerWeapons: {
+        primaryWeaponType: "",
+        primaryWeaponAmmo: 0,
+        secondaryWeaponType: "",
+        secondaryWeaponAmmo: 0,
+        meleeWeaponType: "",
+        meleeWeaponAmmo: 0,
+        throwableWeaponType: "",
+        throwableWeaponAmmo: 0,
+    },
+};
 
-const eventNames = [
-    "gameStart",
-    "gameEnd",
-    "localPlayerDeath",
-    "playerShoot",
-    "localPlayerShoot",
-    "localPlayerKill",
-    "localPlayerHeal",
-    "localPlayerDamage",
-    "localPlayerInventoryItemChange",
-    "localPlayerHelmetChange",
-    "localPlayerChestChange",
-    "localPlayerBackpackChange",
-    "localPlayerOutfitChange",
-    "localPlayerGearChange",
-    "localPlayerEquippedWeaponChange",
-    "localPlayerWeaponChange",
-    "localPlayerWeaponAmmoUsed",
-    "localPlayerWeaponAmmoGained",
-    "localPlayerRemovedItem",
-    "localPlayerAddedItem",
-  ] as const satisfies readonly ModEvent[];  
-
-export interface PlayerKills {
-    totalKills: number;
-}
-
-export interface PlayerHealth {
-    totalHealth: number;
-}
-
-export interface PlayerDamage {
-    totalDamage: number;
-}
-
-export type InferredHealSource = "possiblyRegen" | "likelyItem";
-
-export interface PlayerHeal {
-    totalHeal: number;
-    inferredSource?: InferredHealSource;
-}
-
-export interface PlayerHealRaw {
-    totalHealRaw: number;
-}
-
-export interface PlayerItemAdd {
-    addedItem: string;
-    addedItemAmount: number;
-}
-
-export interface PlayerItemRemove {
-    removedItem: string;
-    removedItemAmount: number;
-}
-
-export interface PlayerHelmetChange {
-    newHelmet: string;
-}
-
-export interface PlayerChestChange {
-    newChest: string;
-}
-
-export interface PlayerBackpackChange {
-    newBackpack: string;
-}
-
-export interface PlayerOutfitChange {
-    newOutfit: string;
-}
-
-export interface PlayerLastGear {
-    gearSlot: string;
-    oldGear: string;
-    newGear: string;
-}
-
-export interface PlayerGearSet {
-    helmet: string;
-    chest: string;
-    backpack: string;
-    outfit: string;
-}
-
-export interface PlayerActiveWeapon {
-    slot: number;
-    weaponType: string;
-    weaponAmmo: number;
-}
-
-export interface PlayerLastWeapon {
-    slot: number;
-    oldWeapon: string;
-    newWeapon: string;
-}
-
-export interface PlayerWeaponAmmoRemove {
-    slot: number;
-    weaponType: string;
-    weaponAmmo: number;
-    ammoUsed: number;
-}
-
-export interface PlayerWeaponAmmoAdd {
-    slot: number;
-    weaponType: string;
-    weaponAmmo: number;
-    ammoGained: number;
-}
-
-export interface PlayerWeapons {
-    primaryWeaponType: string;
-    primaryWeaponAmmo: number;
-    secondaryWeaponType: string;
-    secondaryWeaponAmmo: number;
-    meleeWeaponType: string;
-    meleeWeaponAmmo: number;
-    throwableWeaponType: string;
-    throwableWeaponAmmo: number;
-}
+type GetInfoMap = typeof infoMap;
+type GetMap = keyof GetInfoMap;
+const state: GetInfoMap = { ...infoMap };
 
 export function createModAPI() {
     const listeners: { [E in ModEvent]?: ModEventCallback<E>[] } = {};
 
     const hooks = {} as EventHooks;
 
-    for (const event of eventNames) {
+    for (const event in eventMap) {
+        const typedEvent = event as ModEvent;
         const hookName = `on${capitalize(event)}` as keyof EventHooks;
         hooks[hookName] = (cb: any) => {
-            (listeners[event] ??= []).push(cb);
+            (listeners[typedEvent] ??= []).push(cb);
         };
     }
 
@@ -183,85 +130,39 @@ export function createModAPI() {
         }
     }
 
-    const playerKills: PlayerKills = {
-        totalKills: 0,
+    type Getters = {
+        [K in GetMap as `get${Capitalize<K>}`]: () => Readonly<GetInfoMap[K]>;
     };
-    const playerHealth: PlayerHealth = {
-        totalHealth: 100,
+
+    const getters = {} as any;
+
+    (Object.keys(state) as GetMap[]).forEach((key) => {
+        const getterName = `get${capitalize(key)}`;
+
+        getters[getterName] = () => {
+            return { ...state[key] };
+        };
+    });
+
+    const get = getters as Getters;
+
+    type Setters = {
+        [K in GetMap as `_set${Capitalize<K>}`]: (
+            payload: Partial<GetInfoMap[K]>,
+        ) => void;
     };
-    const playerDamage: PlayerDamage = {
-        totalDamage: 0,
-    };
-    const playerHeal: PlayerHeal = {
-        totalHeal: 0,
-        inferredSource: undefined,
-    };
-    const playerHealRaw: PlayerHealRaw = {
-        totalHealRaw: 0,
-    };
-    const playerItemAdd: PlayerItemAdd = {
-        addedItem: "",
-        addedItemAmount: 0,
-    };
-    const playerItemRemove: PlayerItemRemove = {
-        removedItem: "",
-        removedItemAmount: 0,
-    };
-    const playerHelmetChange: PlayerHelmetChange = {
-        newHelmet: "",
-    };
-    const playerChestChange: PlayerChestChange = {
-        newChest: "",
-    };
-    const playerBackpackChange: PlayerBackpackChange = {
-        newBackpack: "",
-    };
-    const playerOutfitChange: PlayerOutfitChange = {
-        newOutfit: "",
-    };
-    const playerLastGear: PlayerLastGear = {
-        gearSlot: "",
-        oldGear: "",
-        newGear: "",
-    };
-    const playerGearSet: PlayerGearSet = {
-        helmet: "",
-        chest: "",
-        backpack: "",
-        outfit: "",
-    };
-    const playerActiveWeapon: PlayerActiveWeapon = {
-        slot: 0,
-        weaponType: "",
-        weaponAmmo: 0,
-    };
-    const playerLastWeapon: PlayerLastWeapon = {
-        slot: 0,
-        oldWeapon: "",
-        newWeapon: "",
-    };
-    const playerWeaponAmmoRemove: PlayerWeaponAmmoRemove = {
-        slot: 0,
-        weaponType: "",
-        weaponAmmo: 0,
-        ammoUsed: 0,
-    };
-    const playerWeaponAmmoAdd: PlayerWeaponAmmoAdd = {
-        slot: 0,
-        weaponType: "",
-        weaponAmmo: 0,
-        ammoGained: 0,
-    };
-    const playerWeapons: PlayerWeapons = {
-        primaryWeaponType: "",
-        primaryWeaponAmmo: 0,
-        secondaryWeaponType: "",
-        secondaryWeaponAmmo: 0,
-        meleeWeaponType: "",
-        meleeWeaponAmmo: 0,
-        throwableWeaponType: "",
-        throwableWeaponAmmo: 0,
-    };
+
+    const setters = {} as any;
+
+    (Object.keys(state) as GetMap[]).forEach((key) => {
+        const setterName = `_set${capitalize(key)}`;
+
+        setters[setterName] = (payload: Partial<GetInfoMap[typeof key]>) => {
+            Object.assign(state[key], payload);
+        };
+    });
+
+    const _set = setters as Setters;
 
     return Object.freeze({
         // on* hooks start
@@ -269,79 +170,7 @@ export function createModAPI() {
         ...hooks,
         // on* hooks end
         // get* hooks start
-
-        getLocalPlayerKills(): Readonly<PlayerKills> {
-            return { ...playerKills };
-        },
-
-        getLocalPlayerHealth(): Readonly<PlayerHealth> {
-            return { ...playerHealth };
-        },
-
-        getLocalPlayerDamage(): Readonly<PlayerDamage> {
-            return { ...playerDamage };
-        },
-
-        getLocalPlayerHeal(): Readonly<PlayerHeal> {
-            return { ...playerHeal };
-        },
-
-        getLocalPlayerHealRaw(): Readonly<PlayerHealRaw> {
-            return { ...playerHealRaw };
-        },
-
-        getLocalPlayerRemovedItem(): Readonly<PlayerItemRemove> {
-            return { ...playerItemRemove };
-        },
-
-        getLocalPlayerAddedItem(): Readonly<PlayerItemAdd> {
-            return { ...playerItemAdd };
-        },
-
-        getLocalPlayerHelmet(): Readonly<PlayerHelmetChange> {
-            return { ...playerHelmetChange };
-        },
-
-        getLocalPlayerChest(): Readonly<PlayerChestChange> {
-            return { ...playerChestChange };
-        },
-
-        getLocalPlayerBackpack(): Readonly<PlayerBackpackChange> {
-            return { ...playerBackpackChange };
-        },
-
-        getLocalPlayerOutfit(): Readonly<PlayerOutfitChange> {
-            return { ...playerOutfitChange };
-        },
-
-        getLocalPlayerLastChangedGear(): Readonly<PlayerLastGear> {
-            return { ...playerLastGear };
-        },
-
-        getLocalPlayerGear(): Readonly<PlayerGearSet> {
-            return { ...playerGearSet };
-        },
-
-        getLocalPlayerCurrentEquippedWeapon(): Readonly<PlayerActiveWeapon> {
-            return { ...playerActiveWeapon };
-        },
-
-        getLocalPlayerLastChangedWeapon(): Readonly<PlayerLastWeapon> {
-            return { ...playerLastWeapon };
-        },
-
-        getLocalPlayerWeaponAmmoUsed(): Readonly<PlayerWeaponAmmoRemove> {
-            return { ...playerWeaponAmmoRemove };
-        },
-
-        getLocalPlayerWeaponAmmoGained(): Readonly<PlayerWeaponAmmoAdd> {
-            return { ...playerWeaponAmmoAdd };
-        },
-
-        getLocalPlayerWeapons(): Readonly<PlayerWeapons> {
-            return { ...playerWeapons };
-        },
-
+        ...get,
         // _emit* internal hooks start
 
         _emit,
@@ -349,144 +178,7 @@ export function createModAPI() {
         // _emit* internal hooks end
 
         // _set* internal hooks start
-        _setPlayerKills(totalKills: number) {
-            playerKills.totalKills = totalKills;
-        },
-
-        _setLocalPlayerHealth(totalHealth: number) {
-            playerHealth.totalHealth = totalHealth;
-        },
-
-        _setLocalPlayerDamageAmount(totalDamage: number) {
-            playerDamage.totalDamage = totalDamage;
-        },
-        // im probably going to forget this so heres a note for later doc writing
-        // the setLocalPlayerHealAmount is what people use when they want a semi-filtered
-        // heal readout meanwhile the raw one as the name implies is a raw readout
-        // (now that I think of it this is probably hard to forget due to the name but anything can happen I guess...)
-        _setLocalPlayerHealAmount(
-            totalHeal: number,
-            options?: { inferredSource?: InferredHealSource },
-        ) {
-            playerHeal.totalHeal = totalHeal;
-            playerHeal.inferredSource = options?.inferredSource;
-        },
-
-        _setLocalPlayerHealAmountRaw(totalHealRaw: number) {
-            playerHealRaw.totalHealRaw = totalHealRaw;
-        },
-
-        _setLocalPlayerRemoveItem(removedItem: string, removedItemAmount: number) {
-            playerItemRemove.removedItem = removedItem;
-            playerItemRemove.removedItemAmount = removedItemAmount;
-        },
-
-        _setLocalPlayerAddItem(addedItem: string, addedItemAmount: number) {
-            playerItemAdd.addedItem = addedItem;
-            playerItemAdd.addedItemAmount = addedItemAmount;
-        },
-
-        _setLocalPlayerHelmet(newHelmet: string) {
-            playerHelmetChange.newHelmet = newHelmet;
-        },
-
-        _setLocalPlayerChest(newChest: string) {
-            playerChestChange.newChest = newChest;
-        },
-
-        _setLocalPlayerBackpack(newBackpack: string) {
-            playerBackpackChange.newBackpack = newBackpack;
-        },
-
-        _setLocalPlayerOutfit(newOutfit: string) {
-            playerOutfitChange.newOutfit = newOutfit;
-        },
-
-        _setLocalPlayerLastChangedGear(
-            gearSlot: string,
-            oldGear: string,
-            newGear: string,
-        ) {
-            playerLastGear.gearSlot = gearSlot;
-            playerLastGear.oldGear = oldGear;
-            playerLastGear.newGear = newGear;
-        },
-
-        _setLocalPlayerGear(
-            helmet: string,
-            chest: string,
-            backpack: string,
-            outfit: string,
-        ) {
-            playerGearSet.helmet = helmet;
-            playerGearSet.chest = chest;
-            playerGearSet.backpack = backpack;
-            playerGearSet.outfit = outfit;
-        },
-
-        _setLocalPlayerCurrentEquippedWeapon(
-            slot: number,
-            weaponType: string,
-            weaponAmmo: number,
-        ) {
-            playerActiveWeapon.slot = slot;
-            playerActiveWeapon.weaponType = weaponType;
-            playerActiveWeapon.weaponAmmo = weaponAmmo;
-        },
-
-        _setLocalPlayerLastChangedWeapon(
-            slot: number,
-            oldWeapon: string,
-            newWeapon: string,
-        ) {
-            playerLastWeapon.slot = slot;
-            playerLastWeapon.oldWeapon = oldWeapon;
-            playerLastWeapon.newWeapon = newWeapon;
-        },
-
-        _setLocalPlayerWeaponAmmoUsed(
-            slot: number,
-            weaponType: string,
-            weaponAmmo: number,
-            ammoUsed: number,
-        ) {
-            playerWeaponAmmoRemove.slot = slot;
-            playerWeaponAmmoRemove.weaponType = weaponType;
-            playerWeaponAmmoRemove.weaponAmmo = weaponAmmo;
-            playerWeaponAmmoRemove.ammoUsed = ammoUsed;
-        },
-
-        _setLocalPlayerWeaponAmmoGained(
-            slot: number,
-            weaponType: string,
-            weaponAmmo: number,
-            ammoGained: number,
-        ) {
-            playerWeaponAmmoAdd.slot = slot;
-            playerWeaponAmmoAdd.weaponType = weaponType;
-            playerWeaponAmmoAdd.weaponAmmo = weaponAmmo;
-            playerWeaponAmmoAdd.ammoGained = ammoGained;
-        },
-
-        _setLocalPlayerWeapons(
-            primaryWeaponType: string,
-            primaryWeaponAmmo: number,
-            secondaryWeaponType: string,
-            secondaryWeaponAmmo: number,
-            meleeWeaponType: string,
-            meleeWeaponAmmo: number,
-            throwableWeaponType: string,
-            throwableWeaponAmmo: number,
-        ) {
-            playerWeapons.primaryWeaponType = primaryWeaponType;
-            playerWeapons.primaryWeaponAmmo = primaryWeaponAmmo;
-            playerWeapons.secondaryWeaponType = secondaryWeaponType;
-            playerWeapons.secondaryWeaponAmmo = secondaryWeaponAmmo;
-            playerWeapons.meleeWeaponType = meleeWeaponType;
-            playerWeapons.meleeWeaponAmmo = meleeWeaponAmmo;
-            playerWeapons.throwableWeaponType = throwableWeaponType;
-            playerWeapons.throwableWeaponAmmo = throwableWeaponAmmo;
-        },
+        ..._set,
         // _set* internal hooks end
     });
 }

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -1,6 +1,8 @@
 type GameStartListener = () => void;
 type GameEndListener = () => void;
 type PlayerDeathListener = () => void;
+type PlayerShootListener = () => void;
+type PlayerLocalShootListener = () => void;
 
 export interface TextureOverrides {
   [key: string]: string; // key = texture ID, value = URL/path
@@ -10,6 +12,8 @@ export function createModAPI() {
   const gameStartListeners: GameStartListener[] = [];
   const gameEndListeners: GameEndListener[] = [];
   const playerDeathListeners: PlayerDeathListener[] = [];
+  const playerShootListeners: PlayerShootListener[] = [];
+  const playerLocalShootListeners: PlayerLocalShootListener[] = [];
   const textureOverrides: TextureOverrides = {};
 
   return Object.freeze({
@@ -24,6 +28,14 @@ export function createModAPI() {
 
     onPlayerDeath(fn: PlayerDeathListener) {
       playerDeathListeners.push(fn);
+    },
+
+    onPlayerShoot(fn: PlayerShootListener) {
+      playerShootListeners.push(fn);
+    },
+
+    onLocalPlayerShoot(fn: PlayerLocalShootListener) {
+      playerLocalShootListeners.push(fn);
     },
 
     /**
@@ -48,6 +60,14 @@ export function createModAPI() {
 
     _emitPlayerDeath() {
       for (const fn of playerDeathListeners) fn();
+    },
+
+    _emitPlayerShoot() {
+      for (const fn of playerShootListeners) fn();
+    },
+
+    _emitLocalPlayerShoot() {
+      for (const fn of playerLocalShootListeners) fn();
     },
 
     _getTextureOverrides() {

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -1,4 +1,5 @@
 type GameStartListener = () => void;
+type GameEndListener = () => void;
 
 export interface TextureOverrides {
   [key: string]: string; // key = texture ID, value = URL/path
@@ -6,12 +7,17 @@ export interface TextureOverrides {
 
 export function createModAPI() {
   const gameStartListeners: GameStartListener[] = [];
+  const gameEndListeners: GameEndListener[] = [];
   const textureOverrides: TextureOverrides = {};
 
   return Object.freeze({
 
     onGameStart(fn: GameStartListener) {
       gameStartListeners.push(fn);
+    },
+
+    onGameEnd(fn: GameEndListener) {
+      gameEndListeners.push(fn);
     },
 
     /**
@@ -28,6 +34,10 @@ export function createModAPI() {
 
     _emitGameStart() {
       for (const fn of gameStartListeners) fn();
+    },
+
+    _emitGameEnd() {
+      for (const fn of gameEndListeners) fn();
     },
 
     _getTextureOverrides() {

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -104,7 +104,7 @@ export interface PlayerWeaponAmmoAdd {
     slot: number;
     weaponType: string;
     weaponAmmo: number;
-    ammoUsed: number;
+    ammoGained: number;
 }
 
 export interface PlayerWeapons {
@@ -203,7 +203,7 @@ export function createModAPI() {
         slot: 0,
         weaponType: "",
         weaponAmmo: 0,
-        ammoUsed: 0,
+        ammoGained: 0,
     };
     const playerWeaponGainedAmmoListeners: PlayerWeaponGainedAmmoListener[] = [];
     const playerWeapons: PlayerWeapons = {
@@ -572,12 +572,12 @@ export function createModAPI() {
             slot: number,
             weaponType: string,
             weaponAmmo: number,
-            ammoUsed: number,
+            ammoGained: number,
         ) {
             playerWeaponAmmoAdd.slot = slot;
             playerWeaponAmmoAdd.weaponType = weaponType;
             playerWeaponAmmoAdd.weaponAmmo = weaponAmmo;
-            playerWeaponAmmoAdd.ammoUsed = ammoUsed;
+            playerWeaponAmmoAdd.ammoGained = ammoGained;
         },
 
         _setLocalPlayerWeapons(

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -19,10 +19,6 @@ type PlayerWeaponGainedAmmoListener = () => void;
 type PlayerRemovedItemListener = () => void;
 type PlayerAddedItemListener = () => void;
 
-export interface TextureOverrides {
-    [key: string]: string; // key = texture ID, value = URL/path
-};
-
 export interface PlayerKills {
     totalKills: number;
 };
@@ -129,7 +125,6 @@ export function createModAPI() {
     const playerShootListeners: PlayerShootListener[] = [];
     const playerLocalShootListeners: PlayerLocalShootListener[] = [];
     const playerKillListeners: PlayerKillListener[] = [];
-    const textureOverrides: TextureOverrides = {};
     const playerKills: PlayerKills = {
         totalKills: 0,
     };
@@ -234,7 +229,7 @@ export function createModAPI() {
             gameEndListeners.push(fn);
         },
 
-        onPlayerDeath(fn: PlayerDeathListener) {
+        onLocalPlayerDeath(fn: PlayerDeathListener) {
             playerDeathListeners.push(fn);
         },
 
@@ -246,7 +241,7 @@ export function createModAPI() {
             playerLocalShootListeners.push(fn);
         },
 
-        onPlayerKill(fn: PlayerKillListener) {
+        onLocalPlayerKill(fn: PlayerKillListener) {
             playerKillListeners.push(fn);
         },
 
@@ -307,17 +302,7 @@ export function createModAPI() {
         },
 
         // on* hooks end
-        /**
-         * @param textureId string ID of the texture
-         * @param url path/URL to the texture
-         */
-        setLocalPlayerTexture(textureId: string, url: string) {
-            textureOverrides[textureId] = url;
-        },
-
-        getLocalPlayerTextures(): Readonly<TextureOverrides> {
-            return { ...textureOverrides };
-        },
+        // get* hooks start
 
         getPlayerKills(): Readonly<PlayerKills> {
             return { ...playerKills };
@@ -401,7 +386,7 @@ export function createModAPI() {
             for (const fn of gameEndListeners) fn();
         },
 
-        _emitPlayerDeath() {
+        _emitLocalPlayerDeath() {
             for (const fn of playerDeathListeners) fn();
         },
 
@@ -413,7 +398,7 @@ export function createModAPI() {
             for (const fn of playerLocalShootListeners) fn();
         },
 
-        _emitPlayerKill() {
+        _emitLocalPlayerKill() {
             for (const fn of playerKillListeners) fn();
         },
 
@@ -474,14 +459,6 @@ export function createModAPI() {
         },
 
         // _emit* internal hooks end
-
-        // _get* internal hooks start
-
-        _getTextureOverrides() {
-            return textureOverrides;
-        },
-
-        // _get* internal hooks end
 
         // _set* internal hooks start
         _setPlayerKills(totalKills: number) {

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -3,77 +3,114 @@ type GameEndListener = () => void;
 type PlayerDeathListener = () => void;
 type PlayerShootListener = () => void;
 type PlayerLocalShootListener = () => void;
+type PlayerKillListener = () => void;
 
 export interface TextureOverrides {
-  [key: string]: string; // key = texture ID, value = URL/path
+    [key: string]: string; // key = texture ID, value = URL/path
+}
+
+export interface PlayerKills {
+    totalKills: number;
 }
 
 export function createModAPI() {
-  const gameStartListeners: GameStartListener[] = [];
-  const gameEndListeners: GameEndListener[] = [];
-  const playerDeathListeners: PlayerDeathListener[] = [];
-  const playerShootListeners: PlayerShootListener[] = [];
-  const playerLocalShootListeners: PlayerLocalShootListener[] = [];
-  const textureOverrides: TextureOverrides = {};
+    const gameStartListeners: GameStartListener[] = [];
+    const gameEndListeners: GameEndListener[] = [];
+    const playerDeathListeners: PlayerDeathListener[] = [];
+    const playerShootListeners: PlayerShootListener[] = [];
+    const playerLocalShootListeners: PlayerLocalShootListener[] = [];
+    const playerKillListeners: PlayerKillListener[] = [];
+    const textureOverrides: TextureOverrides = {};
+    const playerKills: PlayerKills = {
+        totalKills: 0,
+    };
 
-  return Object.freeze({
+    return Object.freeze({
+        // on* hooks start
+        onGameStart(fn: GameStartListener) {
+            gameStartListeners.push(fn);
+        },
 
-    onGameStart(fn: GameStartListener) {
-      gameStartListeners.push(fn);
-    },
+        onGameEnd(fn: GameEndListener) {
+            gameEndListeners.push(fn);
+        },
 
-    onGameEnd(fn: GameEndListener) {
-      gameEndListeners.push(fn);
-    },
+        onPlayerDeath(fn: PlayerDeathListener) {
+            playerDeathListeners.push(fn);
+        },
 
-    onPlayerDeath(fn: PlayerDeathListener) {
-      playerDeathListeners.push(fn);
-    },
+        onPlayerShoot(fn: PlayerShootListener) {
+            playerShootListeners.push(fn);
+        },
 
-    onPlayerShoot(fn: PlayerShootListener) {
-      playerShootListeners.push(fn);
-    },
+        onLocalPlayerShoot(fn: PlayerLocalShootListener) {
+            playerLocalShootListeners.push(fn);
+        },
 
-    onLocalPlayerShoot(fn: PlayerLocalShootListener) {
-      playerLocalShootListeners.push(fn);
-    },
+        onPlayerKill(fn: PlayerKillListener) {
+            playerKillListeners.push(fn);
+        },
 
-    /**
-     * @param textureId string ID of the texture
-     * @param url path/URL to the texture
-     */
-    setLocalPlayerTexture(textureId: string, url: string) {
-      textureOverrides[textureId] = url;
-    },
+        // on* hooks end
+        /**
+         * @param textureId string ID of the texture
+         * @param url path/URL to the texture
+         */
+        setLocalPlayerTexture(textureId: string, url: string) {
+            textureOverrides[textureId] = url;
+        },
 
-    getLocalPlayerTextures(): Readonly<TextureOverrides> {
-      return { ...textureOverrides };
-    },
+        getLocalPlayerTextures(): Readonly<TextureOverrides> {
+            return { ...textureOverrides };
+        },
 
-    _emitGameStart() {
-      for (const fn of gameStartListeners) fn();
-    },
+        getPlayerKills(): Readonly<PlayerKills> {
+            return { ...playerKills };
+        },
 
-    _emitGameEnd() {
-      for (const fn of gameEndListeners) fn();
-    },
+        // _emit* internal hooks start
 
-    _emitPlayerDeath() {
-      for (const fn of playerDeathListeners) fn();
-    },
+        _emitGameStart() {
+            for (const fn of gameStartListeners) fn();
+        },
 
-    _emitPlayerShoot() {
-      for (const fn of playerShootListeners) fn();
-    },
+        _emitGameEnd() {
+            for (const fn of gameEndListeners) fn();
+        },
 
-    _emitLocalPlayerShoot() {
-      for (const fn of playerLocalShootListeners) fn();
-    },
+        _emitPlayerDeath() {
+            for (const fn of playerDeathListeners) fn();
+        },
 
-    _getTextureOverrides() {
-      return textureOverrides;
-    },
-  });
+        _emitPlayerShoot() {
+            for (const fn of playerShootListeners) fn();
+        },
+
+        _emitLocalPlayerShoot() {
+            for (const fn of playerLocalShootListeners) fn();
+        },
+
+        _emitPlayerKill() {
+            for (const fn of playerKillListeners) fn();
+        },
+
+        // _emit* internal hooks end
+
+        // _get* internal hooks start
+
+        _getTextureOverrides() {
+            return textureOverrides;
+        },
+
+        // _get* internal hooks end
+
+        // _set* internal hooks start
+        _setPlayerKills(totalKills: number) {
+            playerKills.totalKills = totalKills;
+        },
+
+        // _set* internal hooks end
+    });
 }
 
 export type ModAPI = ReturnType<typeof createModAPI>;

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -21,26 +21,26 @@ type PlayerAddedItemListener = () => void;
 
 export interface PlayerKills {
     totalKills: number;
-};
+}
 
 export interface PlayerHealth {
     totalHealth: number;
-};
+}
 
 export interface PlayerDamage {
     totalDamage: number;
-};
+}
 
 export type InferredHealSource = "possiblyRegen" | "likelyItem";
 
 export interface PlayerHeal {
     totalHeal: number;
     inferredSource?: InferredHealSource;
-};
+}
 
 export interface PlayerHealRaw {
     totalHealRaw: number;
-};
+}
 
 export interface PlayerItemAdd {
     addedItem: string;
@@ -141,7 +141,7 @@ export function createModAPI() {
         inferredSource: undefined,
     };
     const playerHealRaw: PlayerHealRaw = {
-        totalHealRaw: 0
+        totalHealRaw: 0,
     };
     const playerItemAdd: PlayerItemAdd = {
         addedItem: "",
@@ -312,7 +312,7 @@ export function createModAPI() {
             return { ...playerHealth };
         },
 
-        getLocalPlayerDamage(): Readonly <PlayerDamage> {
+        getLocalPlayerDamage(): Readonly<PlayerDamage> {
             return { ...playerDamage };
         },
 
@@ -476,7 +476,10 @@ export function createModAPI() {
         // the setLocalPlayerHealAmount is what people use when they want a semi-filtered
         // heal readout meanwhile the raw one as the name implies is a raw readout
         // (now that I think of it this is probably hard to forget due to the name but anything can happen I guess...)
-        _setLocalPlayerHealAmount(totalHeal: number, options?: { inferredSource?: InferredHealSource }) {
+        _setLocalPlayerHealAmount(
+            totalHeal: number,
+            options?: { inferredSource?: InferredHealSource },
+        ) {
             playerHeal.totalHeal = totalHeal;
             playerHeal.inferredSource = options?.inferredSource;
         },
@@ -511,46 +514,82 @@ export function createModAPI() {
             playerOutfitChange.newOutfit = newOutfit;
         },
 
-        _setLocalPlayerLastChangedGear(gearSlot: string, oldGear: string, newGear: string) {
+        _setLocalPlayerLastChangedGear(
+            gearSlot: string,
+            oldGear: string,
+            newGear: string,
+        ) {
             playerLastGear.gearSlot = gearSlot;
             playerLastGear.oldGear = oldGear;
             playerLastGear.newGear = newGear;
         },
 
-        _setLocalPlayerGear(helmet: string, chest: string, backpack: string, outfit: string) {
+        _setLocalPlayerGear(
+            helmet: string,
+            chest: string,
+            backpack: string,
+            outfit: string,
+        ) {
             playerGearSet.helmet = helmet;
             playerGearSet.chest = chest;
             playerGearSet.backpack = backpack;
             playerGearSet.outfit = outfit;
         },
 
-        _setLocalPlayerCurrentEquippedWeapon(slot: number, weaponType: string, weaponAmmo: number) {
+        _setLocalPlayerCurrentEquippedWeapon(
+            slot: number,
+            weaponType: string,
+            weaponAmmo: number,
+        ) {
             playerActiveWeapon.slot = slot;
             playerActiveWeapon.weaponType = weaponType;
             playerActiveWeapon.weaponAmmo = weaponAmmo;
         },
 
-        _setLocalPlayerLastChangedWeapon(slot: number, oldWeapon: string, newWeapon: string) {
+        _setLocalPlayerLastChangedWeapon(
+            slot: number,
+            oldWeapon: string,
+            newWeapon: string,
+        ) {
             playerLastWeapon.slot = slot;
             playerLastWeapon.oldWeapon = oldWeapon;
             playerLastWeapon.newWeapon = newWeapon;
         },
 
-        _setLocalPlayerWeaponAmmoUsed(slot: number, weaponType: string, weaponAmmo: number, ammoUsed: number) {
+        _setLocalPlayerWeaponAmmoUsed(
+            slot: number,
+            weaponType: string,
+            weaponAmmo: number,
+            ammoUsed: number,
+        ) {
             playerWeaponAmmoRemove.slot = slot;
             playerWeaponAmmoRemove.weaponType = weaponType;
             playerWeaponAmmoRemove.weaponAmmo = weaponAmmo;
             playerWeaponAmmoRemove.ammoUsed = ammoUsed;
         },
 
-        _setLocalPlayerWeaponAmmoGained(slot: number, weaponType: string, weaponAmmo: number, ammoUsed: number) {
+        _setLocalPlayerWeaponAmmoGained(
+            slot: number,
+            weaponType: string,
+            weaponAmmo: number,
+            ammoUsed: number,
+        ) {
             playerWeaponAmmoAdd.slot = slot;
             playerWeaponAmmoAdd.weaponType = weaponType;
             playerWeaponAmmoAdd.weaponAmmo = weaponAmmo;
             playerWeaponAmmoAdd.ammoUsed = ammoUsed;
         },
 
-        _setLocalPlayerWeapons(primaryWeaponType: string, primaryWeaponAmmo: number, secondaryWeaponType: string, secondaryWeaponAmmo: number, meleeWeaponType: string, meleeWeaponAmmo: number, throwableWeaponType: string, throwableWeaponAmmo: number) {
+        _setLocalPlayerWeapons(
+            primaryWeaponType: string,
+            primaryWeaponAmmo: number,
+            secondaryWeaponType: string,
+            secondaryWeaponAmmo: number,
+            meleeWeaponType: string,
+            meleeWeaponAmmo: number,
+            throwableWeaponType: string,
+            throwableWeaponAmmo: number,
+        ) {
             playerWeapons.primaryWeaponType = primaryWeaponType;
             playerWeapons.primaryWeaponAmmo = primaryWeaponAmmo;
             playerWeapons.secondaryWeaponType = secondaryWeaponType;
@@ -559,7 +598,7 @@ export function createModAPI() {
             playerWeapons.meleeWeaponAmmo = meleeWeaponAmmo;
             playerWeapons.throwableWeaponType = throwableWeaponType;
             playerWeapons.throwableWeaponAmmo = throwableWeaponAmmo;
-        }
+        },
         // _set* internal hooks end
     });
 }

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -6,6 +6,18 @@ type PlayerLocalShootListener = () => void;
 type PlayerKillListener = () => void;
 type PlayerHealListener = () => void;
 type PlayerDamageListener = () => void;
+type PlayerInventoryListener = () => void;
+type PlayerHelmetListener = () => void;
+type PlayerChestListener = () => void;
+type PlayerBackpackListener = () => void;
+type PlayerOutfitListener = () => void;
+type PlayerGearListener = () => void;
+type PlayerEquippedWeaponListener = () => void;
+type PlayerWeaponListener = () => void;
+type PlayerWeaponUsedAmmoListener = () => void;
+type PlayerWeaponGainedAmmoListener = () => void;
+type PlayerRemovedItemListener = () => void;
+type PlayerAddedItemListener = () => void;
 
 export interface TextureOverrides {
     [key: string]: string; // key = texture ID, value = URL/path
@@ -34,6 +46,82 @@ export interface PlayerHealRaw {
     totalHealRaw: number;
 };
 
+export interface PlayerItemAdd {
+    addedItem: string;
+    addedItemAmount: number;
+}
+
+export interface PlayerItemRemove {
+    removedItem: string;
+    removedItemAmount: number;
+}
+
+export interface PlayerHelmetChange {
+    newHelmet: string;
+}
+
+export interface PlayerChestChange {
+    newChest: string;
+}
+
+export interface PlayerBackpackChange {
+    newBackpack: string;
+}
+
+export interface PlayerOutfitChange {
+    newOutfit: string;
+}
+
+export interface PlayerLastGear {
+    gearSlot: string;
+    oldGear: string;
+    newGear: string;
+}
+
+export interface PlayerGearSet {
+    helmet: string;
+    chest: string;
+    backpack: string;
+    outfit: string;
+}
+
+export interface PlayerActiveWeapon {
+    slot: number;
+    weaponType: string;
+    weaponAmmo: number;
+}
+
+export interface PlayerLastWeapon {
+    slot: number;
+    oldWeapon: string;
+    newWeapon: string;
+}
+
+export interface PlayerWeaponAmmoRemove {
+    slot: number;
+    weaponType: string;
+    weaponAmmo: number;
+    ammoUsed: number;
+}
+
+export interface PlayerWeaponAmmoAdd {
+    slot: number;
+    weaponType: string;
+    weaponAmmo: number;
+    ammoUsed: number;
+}
+
+export interface PlayerWeapons {
+    primaryWeaponType: string;
+    primaryWeaponAmmo: number;
+    secondaryWeaponType: string;
+    secondaryWeaponAmmo: number;
+    meleeWeaponType: string;
+    meleeWeaponAmmo: number;
+    throwableWeaponType: string;
+    throwableWeaponAmmo: number;
+}
+
 export function createModAPI() {
     const gameStartListeners: GameStartListener[] = [];
     const gameEndListeners: GameEndListener[] = [];
@@ -59,7 +147,82 @@ export function createModAPI() {
     };
     const playerHealRaw: PlayerHealRaw = {
         totalHealRaw: 0
-    }
+    };
+    const playerItemAdd: PlayerItemAdd = {
+        addedItem: "",
+        addedItemAmount: 0,
+    };
+    const playerItemRemove: PlayerItemRemove = {
+        removedItem: "",
+        removedItemAmount: 0,
+    };
+    const playerInventoryListeners: PlayerInventoryListener[] = [];
+    const playerHelmetListeners: PlayerHelmetListener[] = [];
+    const playerChestListeners: PlayerChestListener[] = [];
+    const playerBackpackListeners: PlayerBackpackListener[] = [];
+    const playerOutfitListeners: PlayerOutfitListener[] = [];
+    const playerGearListeners: PlayerGearListener[] = [];
+    const playerHelmetChange: PlayerHelmetChange = {
+        newHelmet: "",
+    };
+    const playerChestChange: PlayerChestChange = {
+        newChest: "",
+    };
+    const playerBackpackChange: PlayerBackpackChange = {
+        newBackpack: "",
+    };
+    const playerOutfitChange: PlayerOutfitChange = {
+        newOutfit: "",
+    };
+    const playerLastGear: PlayerLastGear = {
+        gearSlot: "",
+        oldGear: "",
+        newGear: "",
+    };
+    const playerGearSet: PlayerGearSet = {
+        helmet: "",
+        chest: "",
+        backpack: "",
+        outfit: "",
+    };
+    const playerEquippedWeaponListeners: PlayerEquippedWeaponListener[] = [];
+    const playerWeaponListeners: PlayerWeaponListener[] = [];
+    const playerWeaponUsedAmmoListeners: PlayerWeaponUsedAmmoListener[] = [];
+    const playerActiveWeapon: PlayerActiveWeapon = {
+        slot: 0,
+        weaponType: "",
+        weaponAmmo: 0,
+    };
+    const playerLastWeapon: PlayerLastWeapon = {
+        slot: 0,
+        oldWeapon: "",
+        newWeapon: "",
+    };
+    const playerWeaponAmmoRemove: PlayerWeaponAmmoRemove = {
+        slot: 0,
+        weaponType: "",
+        weaponAmmo: 0,
+        ammoUsed: 0,
+    };
+    const playerWeaponAmmoAdd: PlayerWeaponAmmoAdd = {
+        slot: 0,
+        weaponType: "",
+        weaponAmmo: 0,
+        ammoUsed: 0,
+    };
+    const playerWeaponGainedAmmoListeners: PlayerWeaponGainedAmmoListener[] = [];
+    const playerWeapons: PlayerWeapons = {
+        primaryWeaponType: "",
+        primaryWeaponAmmo: 0,
+        secondaryWeaponType: "",
+        secondaryWeaponAmmo: 0,
+        meleeWeaponType: "",
+        meleeWeaponAmmo: 0,
+        throwableWeaponType: "",
+        throwableWeaponAmmo: 0,
+    };
+    const playerRemovedItemListeners: PlayerRemovedItemListener[] = [];
+    const playerAddedItemListeners: PlayerAddedItemListener[] = [];
 
     return Object.freeze({
         // on* hooks start
@@ -95,6 +258,54 @@ export function createModAPI() {
             playerDamageListeners.push(fn);
         },
 
+        onLocalPlayerInventoryItemChange(fn: PlayerInventoryListener) {
+            playerInventoryListeners.push(fn);
+        },
+
+        onLocalPlayerHelmetChange(fn: PlayerHelmetListener) {
+            playerHelmetListeners.push(fn);
+        },
+
+        onLocalPlayerChestChange(fn: PlayerChestListener) {
+            playerChestListeners.push(fn);
+        },
+
+        onLocalPlayerBackpackChange(fn: PlayerBackpackListener) {
+            playerBackpackListeners.push(fn);
+        },
+
+        onLocalPlayerOutfitChange(fn: PlayerOutfitListener) {
+            playerOutfitListeners.push(fn);
+        },
+
+        onLocalPlayerGearChange(fn: PlayerGearListener) {
+            playerGearListeners.push(fn);
+        },
+
+        onLocalPlayerEquippedWeaponChange(fn: PlayerEquippedWeaponListener) {
+            playerEquippedWeaponListeners.push(fn);
+        },
+
+        onLocalPlayerWeaponChange(fn: PlayerWeaponListener) {
+            playerWeaponListeners.push(fn);
+        },
+
+        onLocalPlayerWeaponAmmoUse(fn: PlayerWeaponUsedAmmoListener) {
+            playerWeaponUsedAmmoListeners.push(fn);
+        },
+
+        onLocalPlayerWeaponAmmoGained(fn: PlayerWeaponGainedAmmoListener) {
+            playerWeaponGainedAmmoListeners.push(fn);
+        },
+
+        onLocalPlayerRemovedItem(fn: PlayerRemovedItemListener) {
+            playerRemovedItemListeners.push(fn);
+        },
+
+        onLocalPlayerAddedItem(fn: PlayerAddedItemListener) {
+            playerAddedItemListeners.push(fn);
+        },
+
         // on* hooks end
         /**
          * @param textureId string ID of the texture
@@ -126,6 +337,58 @@ export function createModAPI() {
 
         getLocalPlayerHealRaw(): Readonly<PlayerHealRaw> {
             return { ...playerHealRaw };
+        },
+
+        getLocalPlayerRemovedItem(): Readonly<PlayerItemRemove> {
+            return { ...playerItemRemove };
+        },
+
+        getLocalPlayerAddedItem(): Readonly<PlayerItemAdd> {
+            return { ...playerItemAdd };
+        },
+
+        getLocalPlayerHelmet(): Readonly<PlayerHelmetChange> {
+            return { ...playerHelmetChange };
+        },
+
+        getLocalPlayerChest(): Readonly<PlayerChestChange> {
+            return { ...playerChestChange };
+        },
+
+        getLocalPlayerBackpack(): Readonly<PlayerBackpackChange> {
+            return { ...playerBackpackChange };
+        },
+
+        getLocalPlayerOutfit(): Readonly<PlayerOutfitChange> {
+            return { ...playerOutfitChange };
+        },
+
+        getLocalPlayerLastChangedGear(): Readonly<PlayerLastGear> {
+            return { ...playerLastGear };
+        },
+
+        getLocalPlayerGear(): Readonly<PlayerGearSet> {
+            return { ...playerGearSet };
+        },
+
+        getLocalPlayerCurrentEquippedWeapon(): Readonly<PlayerActiveWeapon> {
+            return { ...playerActiveWeapon };
+        },
+
+        getLocalPlayerLastChangedWeapon(): Readonly<PlayerLastWeapon> {
+            return { ...playerLastWeapon };
+        },
+
+        getLocalPlayerWeaponAmmoUsed(): Readonly<PlayerWeaponAmmoRemove> {
+            return { ...playerWeaponAmmoRemove };
+        },
+
+        getLocalPlayerWeaponAmmoGained(): Readonly<PlayerWeaponAmmoAdd> {
+            return { ...playerWeaponAmmoAdd };
+        },
+
+        getLocalPlayerWeapons(): Readonly<PlayerWeapons> {
+            return { ...playerWeapons };
         },
 
         // _emit* internal hooks start
@@ -160,6 +423,54 @@ export function createModAPI() {
 
         _emitLocalPlayerDamage() {
             for (const fn of playerDamageListeners) fn();
+        },
+
+        _emitLocalPlayerInventoryItemChange() {
+            for (const fn of playerInventoryListeners) fn();
+        },
+
+        _emitLocalPlayerHelmetChange() {
+            for (const fn of playerHelmetListeners) fn();
+        },
+
+        _emitLocalPlayerChestChange() {
+            for (const fn of playerChestListeners) fn();
+        },
+
+        _emitLocalPlayerBackpackChange() {
+            for (const fn of playerBackpackListeners) fn();
+        },
+
+        _emitLocalPlayerOutfitChange() {
+            for (const fn of playerOutfitListeners) fn();
+        },
+
+        _emitLocalPlayerGearChange() {
+            for (const fn of playerGearListeners) fn();
+        },
+
+        _emitLocalPlayerEquippedWeaponChange() {
+            for (const fn of playerEquippedWeaponListeners) fn();
+        },
+
+        _emitLocalPlayerWeaponChange() {
+            for (const fn of playerWeaponListeners) fn();
+        },
+
+        _emitLocalPlayerWeaponAmmoUsed() {
+            for (const fn of playerWeaponUsedAmmoListeners) fn();
+        },
+
+        _emitLocalPlayerWeaponAmmoGained() {
+            for (const fn of playerWeaponGainedAmmoListeners) fn();
+        },
+
+        _emitLocalPlayerRemovedItem() {
+            for (const fn of playerRemovedItemListeners) fn();
+        },
+
+        _emitLocalPlayerAddedItem() {
+            for (const fn of playerAddedItemListeners) fn();
         },
 
         // _emit* internal hooks end
@@ -197,6 +508,81 @@ export function createModAPI() {
             playerHealRaw.totalHealRaw = totalHealRaw;
         },
 
+        _setLocalPlayerRemoveItem(removedItem: string, removedItemAmount: number) {
+            playerItemRemove.removedItem = removedItem;
+            playerItemRemove.removedItemAmount = removedItemAmount;
+        },
+
+        _setLocalPlayerAddItem(addedItem: string, addedItemAmount: number) {
+            playerItemAdd.addedItem = addedItem;
+            playerItemAdd.addedItemAmount = addedItemAmount;
+        },
+
+        _setLocalPlayerHelmet(newHelmet: string) {
+            playerHelmetChange.newHelmet = newHelmet;
+        },
+
+        _setLocalPlayerChest(newChest: string) {
+            playerChestChange.newChest = newChest;
+        },
+
+        _setLocalPlayerBackpack(newBackpack: string) {
+            playerBackpackChange.newBackpack = newBackpack;
+        },
+
+        _setLocalPlayerOutfit(newOutfit: string) {
+            playerOutfitChange.newOutfit = newOutfit;
+        },
+
+        _setLocalPlayerLastChangedGear(gearSlot: string, oldGear: string, newGear: string) {
+            playerLastGear.gearSlot = gearSlot;
+            playerLastGear.oldGear = oldGear;
+            playerLastGear.newGear = newGear;
+        },
+
+        _setLocalPlayerGear(helmet: string, chest: string, backpack: string, outfit: string) {
+            playerGearSet.helmet = helmet;
+            playerGearSet.chest = chest;
+            playerGearSet.backpack = backpack;
+            playerGearSet.outfit = outfit;
+        },
+
+        _setLocalPlayerCurrentEquippedWeapon(slot: number, weaponType: string, weaponAmmo: number) {
+            playerActiveWeapon.slot = slot;
+            playerActiveWeapon.weaponType = weaponType;
+            playerActiveWeapon.weaponAmmo = weaponAmmo;
+        },
+
+        _setLocalPlayerLastChangedWeapon(slot: number, oldWeapon: string, newWeapon: string) {
+            playerLastWeapon.slot = slot;
+            playerLastWeapon.oldWeapon = oldWeapon;
+            playerLastWeapon.newWeapon = newWeapon;
+        },
+
+        _setLocalPlayerWeaponAmmoUsed(slot: number, weaponType: string, weaponAmmo: number, ammoUsed: number) {
+            playerWeaponAmmoRemove.slot = slot;
+            playerWeaponAmmoRemove.weaponType = weaponType;
+            playerWeaponAmmoRemove.weaponAmmo = weaponAmmo;
+            playerWeaponAmmoRemove.ammoUsed = ammoUsed;
+        },
+
+        _setLocalPlayerWeaponAmmoGained(slot: number, weaponType: string, weaponAmmo: number, ammoUsed: number) {
+            playerWeaponAmmoAdd.slot = slot;
+            playerWeaponAmmoAdd.weaponType = weaponType;
+            playerWeaponAmmoAdd.weaponAmmo = weaponAmmo;
+            playerWeaponAmmoAdd.ammoUsed = ammoUsed;
+        },
+
+        _setLocalPlayerWeapons(primaryWeaponType: string, primaryWeaponAmmo: number, secondaryWeaponType: string, secondaryWeaponAmmo: number, meleeWeaponType: string, meleeWeaponAmmo: number, throwableWeaponType: string, throwableWeaponAmmo: number) {
+            playerWeapons.primaryWeaponType = primaryWeaponType;
+            playerWeapons.primaryWeaponAmmo = primaryWeaponAmmo;
+            playerWeapons.secondaryWeaponType = secondaryWeaponType;
+            playerWeapons.secondaryWeaponAmmo = secondaryWeaponAmmo;
+            playerWeapons.meleeWeaponType = meleeWeaponType;
+            playerWeapons.meleeWeaponAmmo = meleeWeaponAmmo;
+            playerWeapons.throwableWeaponType = throwableWeaponType;
+            playerWeapons.throwableWeaponAmmo = throwableWeaponAmmo;
+        }
         // _set* internal hooks end
     });
 }

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -1,5 +1,6 @@
 type GameStartListener = () => void;
 type GameEndListener = () => void;
+type PlayerDeathListener = () => void;
 
 export interface TextureOverrides {
   [key: string]: string; // key = texture ID, value = URL/path
@@ -8,6 +9,7 @@ export interface TextureOverrides {
 export function createModAPI() {
   const gameStartListeners: GameStartListener[] = [];
   const gameEndListeners: GameEndListener[] = [];
+  const playerDeathListeners: PlayerDeathListener[] = [];
   const textureOverrides: TextureOverrides = {};
 
   return Object.freeze({
@@ -18,6 +20,10 @@ export function createModAPI() {
 
     onGameEnd(fn: GameEndListener) {
       gameEndListeners.push(fn);
+    },
+
+    onPlayerDeath(fn: PlayerDeathListener) {
+      playerDeathListeners.push(fn);
     },
 
     /**
@@ -38,6 +44,10 @@ export function createModAPI() {
 
     _emitGameEnd() {
       for (const fn of gameEndListeners) fn();
+    },
+
+    _emitPlayerDeath() {
+      for (const fn of playerDeathListeners) fn();
     },
 
     _getTextureOverrides() {

--- a/client/src/modding/ModAPI.ts
+++ b/client/src/modding/ModAPI.ts
@@ -304,7 +304,7 @@ export function createModAPI() {
         // on* hooks end
         // get* hooks start
 
-        getPlayerKills(): Readonly<PlayerKills> {
+        getLocalPlayerKills(): Readonly<PlayerKills> {
             return { ...playerKills };
         },
 

--- a/client/src/modding/ModAPIInstance.ts
+++ b/client/src/modding/ModAPIInstance.ts
@@ -1,0 +1,7 @@
+import { createModAPI, ModAPI } from "./ModAPI";
+
+const modAPI: ModAPI = window.__MYGAME_MOD_API__ ?? createModAPI();
+
+window.__MYGAME_MOD_API__ = modAPI;
+
+export { modAPI };

--- a/client/src/modding/ModAPIInstance.ts
+++ b/client/src/modding/ModAPIInstance.ts
@@ -1,4 +1,4 @@
-import { createModAPI, ModAPI } from "./ModAPI";
+import { createModAPI, type ModAPI } from "./ModAPI";
 
 const modAPI: ModAPI = window.__MYGAME_MOD_API__ ?? createModAPI();
 

--- a/client/src/modding/ModAPIInstance.ts
+++ b/client/src/modding/ModAPIInstance.ts
@@ -1,7 +1,7 @@
 import { createModAPI, type ModAPI } from "./ModAPI";
 
-const modAPI: ModAPI = window.__MYGAME_MOD_API__ ?? createModAPI();
+const modAPI: ModAPI = window.survevModAPI ?? createModAPI();
 
-window.__MYGAME_MOD_API__ = modAPI;
+window.survevModAPI = modAPI;
 
 export { modAPI };

--- a/client/src/modding/ModAPIInstance.ts
+++ b/client/src/modding/ModAPIInstance.ts
@@ -4,4 +4,6 @@ const modAPI: ModAPI = window.survevModAPI ?? createModAPI();
 
 window.survevModAPI = modAPI;
 
+console.log("Come view the survevModAPI docs at (add the link here later...)");
+
 export { modAPI };

--- a/client/src/objects/player.ts
+++ b/client/src/objects/player.ts
@@ -2746,7 +2746,7 @@ export class PlayerBarn {
         const isDead = activePlayer.m_netData.m_dead;
 
         if (!this.wasDead && isDead) {
-            modAPI._emitPlayerDeath();
+            modAPI._emitLocalPlayerDeath();
         }
 
         this.wasDead = isDead;

--- a/client/src/objects/player.ts
+++ b/client/src/objects/player.ts
@@ -619,36 +619,52 @@ export class Player implements AbstractObject {
             const newChest = this.m_netData.m_chest;
             const newBackpack = this.m_netData.m_backpack;
             const newOutfit = this.m_netData.m_outfit;
-            modAPI._setLocalPlayerGear(newHelmet, newChest, newBackpack, newOutfit,);
+            modAPI._setLocalPlayerGear(newHelmet, newChest, newBackpack, newOutfit);
 
             if (oldHelmet !== this.m_netData.m_helmet) {
                 modAPI._setLocalPlayerHelmet(this.m_netData.m_helmet);
-                modAPI._setLocalPlayerLastChangedGear("helmet", oldHelmet, this.m_netData.m_helmet);
+                modAPI._setLocalPlayerLastChangedGear(
+                    "helmet",
+                    oldHelmet,
+                    this.m_netData.m_helmet,
+                );
                 modAPI._emitLocalPlayerHelmetChange();
                 anyGearChanged = true;
             }
             if (oldChest !== this.m_netData.m_chest) {
                 modAPI._setLocalPlayerChest(this.m_netData.m_chest);
-                modAPI._setLocalPlayerLastChangedGear("chest", oldChest, this.m_netData.m_chest);
+                modAPI._setLocalPlayerLastChangedGear(
+                    "chest",
+                    oldChest,
+                    this.m_netData.m_chest,
+                );
                 modAPI._emitLocalPlayerChestChange();
                 anyGearChanged = true;
             }
             if (oldBackpack !== this.m_netData.m_backpack) {
                 modAPI._setLocalPlayerBackpack(this.m_netData.m_backpack);
-                modAPI._setLocalPlayerLastChangedGear("backpack", oldBackpack, this.m_netData.m_backpack);
+                modAPI._setLocalPlayerLastChangedGear(
+                    "backpack",
+                    oldBackpack,
+                    this.m_netData.m_backpack,
+                );
                 modAPI._emitLocalPlayerBackpackChange();
                 anyGearChanged = true;
             }
             if (oldOutfit !== this.m_netData.m_outfit) {
                 modAPI._setLocalPlayerOutfit(this.m_netData.m_outfit);
-                modAPI._setLocalPlayerLastChangedGear("outfit", oldOutfit, this.m_netData.m_outfit);
+                modAPI._setLocalPlayerLastChangedGear(
+                    "outfit",
+                    oldOutfit,
+                    this.m_netData.m_outfit,
+                );
                 modAPI._emitLocalPlayerOutfitChange();
                 anyGearChanged = true;
             }
             if (anyGearChanged) {
                 modAPI._emitLocalPlayerGearChange();
             }
-        }        
+        }
     }
 
     m_setLocalData(data: LocalDataWithDirty) {
@@ -664,10 +680,10 @@ export class Player implements AbstractObject {
             const oldHealth = this.m_localData.m_health;
             const newHealth = data.health;
             const healthDelta = newHealth - oldHealth;
-            
+
             this.m_localData.m_health = newHealth;
             modAPI._setLocalPlayerHealth(data.health);
-            
+
             if (healthDelta < 0) {
                 modAPI._setLocalPlayerDamageAmount(-healthDelta);
                 modAPI._emitLocalPlayerDamage();
@@ -679,7 +695,7 @@ export class Player implements AbstractObject {
                 modAPI._setLocalPlayerHealAmount(healthDelta, {
                     inferredSource: healMightBeRegen ? "possiblyRegen" : "likelyItem",
                 });
-                
+
                 modAPI._setLocalPlayerHealAmountRaw(healthDelta);
                 modAPI._emitLocalPlayerHeal();
             }
@@ -697,7 +713,7 @@ export class Player implements AbstractObject {
         }
 
         if (data.inventoryDirty) {
-            const oldInventory = {  ...this.m_localData.m_inventory  };
+            const oldInventory = { ...this.m_localData.m_inventory };
 
             this.m_localData.m_scope = data.scope;
             this.m_localData.m_inventory = {};
@@ -708,7 +724,7 @@ export class Player implements AbstractObject {
             }
 
             const newInventory = { ...this.m_localData.m_inventory };
-            
+
             for (const item in newInventory) {
                 const oldItem = oldInventory[item] ?? 0;
                 const newItem = newInventory[item] ?? 0;
@@ -725,7 +741,7 @@ export class Player implements AbstractObject {
             modAPI._emitLocalPlayerInventoryItemChange();
         }
         if (data.weapsDirty) {
-            const oldWeaponSlots = this.m_localData.m_weapons.map(w => ({
+            const oldWeaponSlots = this.m_localData.m_weapons.map((w) => ({
                 type: w.type,
                 ammo: w.ammo,
             }));
@@ -744,32 +760,59 @@ export class Player implements AbstractObject {
             }
             const newWeaponSlots = this.m_localData.m_weapons;
 
-            modAPI._setLocalPlayerWeapons(newWeaponSlots[0].type, newWeaponSlots[0].ammo, newWeaponSlots[1].type, newWeaponSlots[1].ammo, newWeaponSlots[2].type, newWeaponSlots[2].ammo, newWeaponSlots[3].type, newWeaponSlots[3].ammo);
+            modAPI._setLocalPlayerWeapons(
+                newWeaponSlots[0].type,
+                newWeaponSlots[0].ammo,
+                newWeaponSlots[1].type,
+                newWeaponSlots[1].ammo,
+                newWeaponSlots[2].type,
+                newWeaponSlots[2].ammo,
+                newWeaponSlots[3].type,
+                newWeaponSlots[3].ammo,
+            );
 
             if (currentIdxChange) {
                 const newWeapon = newWeaponSlots[newIdx];
 
-                modAPI._setLocalPlayerCurrentEquippedWeapon(newIdx, newWeapon.type, newWeapon.ammo);
+                modAPI._setLocalPlayerCurrentEquippedWeapon(
+                    newIdx,
+                    newWeapon.type,
+                    newWeapon.ammo,
+                );
                 modAPI._emitLocalPlayerEquippedWeaponChange();
             }
 
             for (let i = 0; i < newWeaponSlots.length; i++) {
                 const oldWeapon = oldWeaponSlots[i] ?? { type: "", ammo: 0 };
                 const newWeapon = newWeaponSlots[i];
-        
+
                 if (oldWeapon.type !== newWeapon.type) {
-                    modAPI._setLocalPlayerLastChangedWeapon(i, oldWeapon.type, newWeapon.type);
+                    modAPI._setLocalPlayerLastChangedWeapon(
+                        i,
+                        oldWeapon.type,
+                        newWeapon.type,
+                    );
                     modAPI._emitLocalPlayerWeaponChange();
                     continue;
                 }
-        
+
                 const ammoDelta = newWeapon.ammo - oldWeapon.ammo;
 
                 if (ammoDelta < 0) {
-                    modAPI._setLocalPlayerWeaponAmmoUsed(i, newWeapon.type, newWeapon.ammo, -ammoDelta);
+                    modAPI._setLocalPlayerWeaponAmmoUsed(
+                        i,
+                        newWeapon.type,
+                        newWeapon.ammo,
+                        -ammoDelta,
+                    );
                     modAPI._emitLocalPlayerWeaponAmmoUsed();
                 } else if (ammoDelta > 0) {
-                    modAPI._setLocalPlayerWeaponAmmoGained(i, newWeapon.type, newWeapon.ammo, ammoDelta);
+                    modAPI._setLocalPlayerWeaponAmmoGained(
+                        i,
+                        newWeapon.type,
+                        newWeapon.ammo,
+                        ammoDelta,
+                    );
                     modAPI._emitLocalPlayerWeaponAmmoGained();
                 }
             }

--- a/client/src/objects/player.ts
+++ b/client/src/objects/player.ts
@@ -57,6 +57,7 @@ import type { Obstacle } from "./obstacle";
 import type { Emitter, ParticleBarn } from "./particles";
 import { halloweenSpriteMap } from "./projectile";
 import { createCasingParticle } from "./shot";
+import { modAPI } from "../modding/ModAPIInstance";
 
 const submergeMaskScaleFactor = 0.1;
 
@@ -2554,6 +2555,7 @@ export class PlayerBarn {
 
     playerStatus: Record<number, PlayerStatus> = {};
     anonPlayerNames = false;
+    private wasDead = false;
 
     m_update(
         dt: number,
@@ -2600,7 +2602,15 @@ export class PlayerBarn {
         // have not yet received an update for ourselves yet, but
         // we always expect the local data to be available.
         const activeInfo = this.getPlayerInfo(activeId);
-        const activePlayer = this.getPlayerById(activeId)!;
+        const activePlayer = this.getPlayerById(activeId)!;        
+
+        const isDead = activePlayer.m_netData.m_dead;
+
+        if (!this.wasDead && isDead) {
+            modAPI._emitPlayerDeath();
+        }
+
+        this.wasDead = isDead;
 
         this.setPlayerStatus(activeId, {
             pos: v2.copy(activePlayer.m_netData.m_pos),

--- a/client/src/objects/player.ts
+++ b/client/src/objects/player.ts
@@ -619,45 +619,52 @@ export class Player implements AbstractObject {
             const newChest = this.m_netData.m_chest;
             const newBackpack = this.m_netData.m_backpack;
             const newOutfit = this.m_netData.m_outfit;
-            modAPI._setLocalPlayerGear(newHelmet, newChest, newBackpack, newOutfit);
+            modAPI._setLocalPlayerGear({
+                helmet: newHelmet,
+                chest: newChest,
+                backpack: newBackpack,
+                outfit: newOutfit,
+            });
 
             if (oldHelmet !== this.m_netData.m_helmet) {
-                modAPI._setLocalPlayerHelmet(this.m_netData.m_helmet);
-                modAPI._setLocalPlayerLastChangedGear(
-                    "helmet",
-                    oldHelmet,
-                    this.m_netData.m_helmet,
-                );
+                modAPI._setLocalPlayerHelmet({ newHelmet: this.m_netData.m_helmet });
+                modAPI._setLocalPlayerLastChangedGear({
+                    gearSlot: "helmet",
+                    oldGear: oldHelmet,
+                    newGear: this.m_netData.m_helmet,
+                });
                 modAPI._emit("localPlayerHelmetChange", undefined);
                 anyGearChanged = true;
             }
             if (oldChest !== this.m_netData.m_chest) {
-                modAPI._setLocalPlayerChest(this.m_netData.m_chest);
-                modAPI._setLocalPlayerLastChangedGear(
-                    "chest",
-                    oldChest,
-                    this.m_netData.m_chest,
-                );
+                modAPI._setLocalPlayerChest({ newChest: this.m_netData.m_chest });
+                modAPI._setLocalPlayerLastChangedGear({
+                    gearSlot: "chest",
+                    oldGear: oldChest,
+                    newGear: this.m_netData.m_chest,
+                });
                 modAPI._emit("localPlayerChestChange", undefined);
                 anyGearChanged = true;
             }
             if (oldBackpack !== this.m_netData.m_backpack) {
-                modAPI._setLocalPlayerBackpack(this.m_netData.m_backpack);
-                modAPI._setLocalPlayerLastChangedGear(
-                    "backpack",
-                    oldBackpack,
-                    this.m_netData.m_backpack,
-                );
+                modAPI._setLocalPlayerBackpack({
+                    newBackpack: this.m_netData.m_backpack,
+                });
+                modAPI._setLocalPlayerLastChangedGear({
+                    gearSlot: "backpack",
+                    oldGear: oldBackpack,
+                    newGear: this.m_netData.m_backpack,
+                });
                 modAPI._emit("localPlayerBackpackChange", undefined);
                 anyGearChanged = true;
             }
             if (oldOutfit !== this.m_netData.m_outfit) {
-                modAPI._setLocalPlayerOutfit(this.m_netData.m_outfit);
-                modAPI._setLocalPlayerLastChangedGear(
-                    "outfit",
-                    oldOutfit,
-                    this.m_netData.m_outfit,
-                );
+                modAPI._setLocalPlayerOutfit({ newOutfit: this.m_netData.m_outfit });
+                modAPI._setLocalPlayerLastChangedGear({
+                    gearSlot: "outfit",
+                    oldGear: oldOutfit,
+                    newGear: this.m_netData.m_outfit,
+                });
                 modAPI._emit("localPlayerOutfitChange", undefined);
                 anyGearChanged = true;
             }
@@ -682,21 +689,22 @@ export class Player implements AbstractObject {
             const healthDelta = newHealth - oldHealth;
 
             this.m_localData.m_health = newHealth;
-            modAPI._setLocalPlayerHealth(data.health);
+            modAPI._setLocalPlayerHealth({ totalHealth: data.health });
 
             if (healthDelta < 0) {
-                modAPI._setLocalPlayerDamageAmount(-healthDelta);
+                modAPI._setLocalPlayerDamage({ totalDamage: -healthDelta });
                 modAPI._emit("localPlayerDamage", undefined);
             } else if (healthDelta > 0) {
                 const adrenActive = this.m_localData.m_boost > 0;
                 const smallishHeal = healthDelta <= 15;
                 const healMightBeRegen = adrenActive || smallishHeal;
 
-                modAPI._setLocalPlayerHealAmount(healthDelta, {
+                modAPI._setLocalPlayerHeal({
+                    totalHeal: healthDelta,
                     inferredSource: healMightBeRegen ? "possiblyRegen" : "likelyItem",
                 });
 
-                modAPI._setLocalPlayerHealAmountRaw(healthDelta);
+                modAPI._setLocalPlayerHealRaw({ totalHealRaw: healthDelta });
                 modAPI._emit("localPlayerHeal", undefined);
             }
         }
@@ -731,10 +739,16 @@ export class Player implements AbstractObject {
                 const inventoryDelta = newItem - oldItem;
 
                 if (inventoryDelta < 0) {
-                    modAPI._setLocalPlayerRemoveItem(item, -inventoryDelta);
+                    modAPI._setLocalPlayerRemovedItem({
+                        removedItem: item,
+                        removedItemAmount: -inventoryDelta,
+                    });
                     modAPI._emit("localPlayerRemovedItem", undefined);
                 } else if (inventoryDelta > 0) {
-                    modAPI._setLocalPlayerAddItem(item, inventoryDelta);
+                    modAPI._setLocalPlayerAddedItem({
+                        addedItem: item,
+                        addedItemAmount: inventoryDelta,
+                    });
                     modAPI._emit("localPlayerAddedItem", undefined);
                 }
             }
@@ -760,25 +774,25 @@ export class Player implements AbstractObject {
             }
             const newWeaponSlots = this.m_localData.m_weapons;
 
-            modAPI._setLocalPlayerWeapons(
-                newWeaponSlots[0].type,
-                newWeaponSlots[0].ammo,
-                newWeaponSlots[1].type,
-                newWeaponSlots[1].ammo,
-                newWeaponSlots[2].type,
-                newWeaponSlots[2].ammo,
-                newWeaponSlots[3].type,
-                newWeaponSlots[3].ammo,
-            );
+            modAPI._setLocalPlayerWeapons({
+                primaryWeaponType: newWeaponSlots[0].type,
+                primaryWeaponAmmo: newWeaponSlots[0].ammo,
+                secondaryWeaponType: newWeaponSlots[1].type,
+                secondaryWeaponAmmo: newWeaponSlots[1].ammo,
+                meleeWeaponType: newWeaponSlots[2].type,
+                meleeWeaponAmmo: newWeaponSlots[2].ammo,
+                throwableWeaponType: newWeaponSlots[3].type,
+                throwableWeaponAmmo: newWeaponSlots[3].ammo,
+            });
 
             if (currentIdxChange) {
                 const newWeapon = newWeaponSlots[newIdx];
 
-                modAPI._setLocalPlayerCurrentEquippedWeapon(
-                    newIdx,
-                    newWeapon.type,
-                    newWeapon.ammo,
-                );
+                modAPI._setLocalPlayerCurrentEquippedWeapon({
+                    slot: newIdx,
+                    weaponType: newWeapon.type,
+                    weaponAmmo: newWeapon.ammo,
+                });
                 modAPI._emit("localPlayerEquippedWeaponChange", undefined);
             }
 
@@ -787,11 +801,11 @@ export class Player implements AbstractObject {
                 const newWeapon = newWeaponSlots[i];
 
                 if (oldWeapon.type !== newWeapon.type) {
-                    modAPI._setLocalPlayerLastChangedWeapon(
-                        i,
-                        oldWeapon.type,
-                        newWeapon.type,
-                    );
+                    modAPI._setLocalPlayerLastChangedWeapon({
+                        slot: i,
+                        oldWeapon: oldWeapon.type,
+                        newWeapon: newWeapon.type,
+                    });
                     modAPI._emit("localPlayerWeaponChange", undefined);
                     continue;
                 }
@@ -799,20 +813,20 @@ export class Player implements AbstractObject {
                 const ammoDelta = newWeapon.ammo - oldWeapon.ammo;
 
                 if (ammoDelta < 0) {
-                    modAPI._setLocalPlayerWeaponAmmoUsed(
-                        i,
-                        newWeapon.type,
-                        newWeapon.ammo,
-                        -ammoDelta,
-                    );
+                    modAPI._setLocalPlayerWeaponAmmoUsed({
+                        slot: i,
+                        weaponType: newWeapon.type,
+                        weaponAmmo: newWeapon.ammo,
+                        ammoUsed: -ammoDelta,
+                    });
                     modAPI._emit("localPlayerWeaponAmmoUsed", undefined);
                 } else if (ammoDelta > 0) {
-                    modAPI._setLocalPlayerWeaponAmmoGained(
-                        i,
-                        newWeapon.type,
-                        newWeapon.ammo,
-                        ammoDelta,
-                    );
+                    modAPI._setLocalPlayerWeaponAmmoGained({
+                        slot: i,
+                        weaponType: newWeapon.type,
+                        weaponAmmo: newWeapon.ammo,
+                        ammoGained: ammoDelta,
+                    });
                     modAPI._emit("localPlayerWeaponAmmoGained", undefined);
                 }
             }

--- a/client/src/objects/player.ts
+++ b/client/src/objects/player.ts
@@ -50,6 +50,7 @@ import type { InputHandler } from "../input";
 import type { InputBinds } from "./../inputBinds";
 import type { SoundHandle } from "../lib/createJS";
 import type { Map } from "../map";
+import { modAPI } from "../modding/ModAPIInstance";
 import type { Renderer } from "../renderer";
 import type { UiManager2 } from "../ui/ui2";
 import { Pool } from "./objectPool";
@@ -57,7 +58,6 @@ import type { Obstacle } from "./obstacle";
 import type { Emitter, ParticleBarn } from "./particles";
 import { halloweenSpriteMap } from "./projectile";
 import { createCasingParticle } from "./shot";
-import { modAPI } from "../modding/ModAPIInstance";
 
 const submergeMaskScaleFactor = 0.1;
 
@@ -2602,7 +2602,7 @@ export class PlayerBarn {
         // have not yet received an update for ourselves yet, but
         // we always expect the local data to be available.
         const activeInfo = this.getPlayerInfo(activeId);
-        const activePlayer = this.getPlayerById(activeId)!;        
+        const activePlayer = this.getPlayerById(activeId)!;
 
         const isDead = activePlayer.m_netData.m_dead;
 

--- a/client/src/objects/player.ts
+++ b/client/src/objects/player.ts
@@ -628,7 +628,7 @@ export class Player implements AbstractObject {
                     oldHelmet,
                     this.m_netData.m_helmet,
                 );
-                modAPI._emitLocalPlayerHelmetChange();
+                modAPI._emit("localPlayerHelmetChange", undefined);
                 anyGearChanged = true;
             }
             if (oldChest !== this.m_netData.m_chest) {
@@ -638,7 +638,7 @@ export class Player implements AbstractObject {
                     oldChest,
                     this.m_netData.m_chest,
                 );
-                modAPI._emitLocalPlayerChestChange();
+                modAPI._emit("localPlayerChestChange", undefined);
                 anyGearChanged = true;
             }
             if (oldBackpack !== this.m_netData.m_backpack) {
@@ -648,7 +648,7 @@ export class Player implements AbstractObject {
                     oldBackpack,
                     this.m_netData.m_backpack,
                 );
-                modAPI._emitLocalPlayerBackpackChange();
+                modAPI._emit("localPlayerBackpackChange", undefined);
                 anyGearChanged = true;
             }
             if (oldOutfit !== this.m_netData.m_outfit) {
@@ -658,11 +658,11 @@ export class Player implements AbstractObject {
                     oldOutfit,
                     this.m_netData.m_outfit,
                 );
-                modAPI._emitLocalPlayerOutfitChange();
+                modAPI._emit("localPlayerOutfitChange", undefined);
                 anyGearChanged = true;
             }
             if (anyGearChanged) {
-                modAPI._emitLocalPlayerGearChange();
+                modAPI._emit("localPlayerGearChange", undefined);
             }
         }
     }
@@ -686,7 +686,7 @@ export class Player implements AbstractObject {
 
             if (healthDelta < 0) {
                 modAPI._setLocalPlayerDamageAmount(-healthDelta);
-                modAPI._emitLocalPlayerDamage();
+                modAPI._emit("localPlayerDamage", undefined);
             } else if (healthDelta > 0) {
                 const adrenActive = this.m_localData.m_boost > 0;
                 const smallishHeal = healthDelta <= 15;
@@ -697,7 +697,7 @@ export class Player implements AbstractObject {
                 });
 
                 modAPI._setLocalPlayerHealAmountRaw(healthDelta);
-                modAPI._emitLocalPlayerHeal();
+                modAPI._emit("localPlayerHeal", undefined);
             }
         }
 
@@ -732,13 +732,13 @@ export class Player implements AbstractObject {
 
                 if (inventoryDelta < 0) {
                     modAPI._setLocalPlayerRemoveItem(item, -inventoryDelta);
-                    modAPI._emitLocalPlayerRemovedItem();
+                    modAPI._emit("localPlayerRemovedItem", undefined);
                 } else if (inventoryDelta > 0) {
                     modAPI._setLocalPlayerAddItem(item, inventoryDelta);
-                    modAPI._emitLocalPlayerAddedItem();
+                    modAPI._emit("localPlayerAddedItem", undefined);
                 }
             }
-            modAPI._emitLocalPlayerInventoryItemChange();
+            modAPI._emit("localPlayerInventoryItemChange", undefined);
         }
         if (data.weapsDirty) {
             const oldWeaponSlots = this.m_localData.m_weapons.map((w) => ({
@@ -779,7 +779,7 @@ export class Player implements AbstractObject {
                     newWeapon.type,
                     newWeapon.ammo,
                 );
-                modAPI._emitLocalPlayerEquippedWeaponChange();
+                modAPI._emit("localPlayerEquippedWeaponChange", undefined);
             }
 
             for (let i = 0; i < newWeaponSlots.length; i++) {
@@ -792,7 +792,7 @@ export class Player implements AbstractObject {
                         oldWeapon.type,
                         newWeapon.type,
                     );
-                    modAPI._emitLocalPlayerWeaponChange();
+                    modAPI._emit("localPlayerWeaponChange", undefined);
                     continue;
                 }
 
@@ -805,7 +805,7 @@ export class Player implements AbstractObject {
                         newWeapon.ammo,
                         -ammoDelta,
                     );
-                    modAPI._emitLocalPlayerWeaponAmmoUsed();
+                    modAPI._emit("localPlayerWeaponAmmoUsed", undefined);
                 } else if (ammoDelta > 0) {
                     modAPI._setLocalPlayerWeaponAmmoGained(
                         i,
@@ -813,7 +813,7 @@ export class Player implements AbstractObject {
                         newWeapon.ammo,
                         ammoDelta,
                     );
-                    modAPI._emitLocalPlayerWeaponAmmoGained();
+                    modAPI._emit("localPlayerWeaponAmmoGained", undefined);
                 }
             }
         }
@@ -2789,7 +2789,7 @@ export class PlayerBarn {
         const isDead = activePlayer.m_netData.m_dead;
 
         if (!this.wasDead && isDead) {
-            modAPI._emitLocalPlayerDeath();
+            modAPI._emit("localPlayerDeath", undefined);
         }
 
         this.wasDead = isDead;

--- a/client/src/objects/shot.ts
+++ b/client/src/objects/shot.ts
@@ -4,9 +4,9 @@ import { GameConfig } from "../../../shared/gameConfig";
 import type { Bullet } from "../../../shared/net/updateMsg";
 import { type Vec2, v2 } from "../../../shared/utils/v2";
 import type { AudioManager } from "../audioManager";
+import { modAPI } from "../modding/ModAPIInstance";
 import type { ParticleBarn } from "./particles";
 import type { PlayerBarn } from "./player";
-import { modAPI } from "../modding/ModAPIInstance";
 
 interface Shot {
     active: boolean;
@@ -120,7 +120,7 @@ export class ShotBarn {
                     }
                     if (shot.ticker == 0 && shot.playerId !== activePlayerId) {
                         modAPI._emitPlayerShoot();
-                    }                    
+                    }
                     const player = playerBarn.getPlayerById(shot.playerId);
 
                     // Play shot sound

--- a/client/src/objects/shot.ts
+++ b/client/src/objects/shot.ts
@@ -6,6 +6,7 @@ import { type Vec2, v2 } from "../../../shared/utils/v2";
 import type { AudioManager } from "../audioManager";
 import type { ParticleBarn } from "./particles";
 import type { PlayerBarn } from "./player";
+import { modAPI } from "../modding/ModAPIInstance";
 
 interface Shot {
     active: boolean;
@@ -114,6 +115,12 @@ export class ShotBarn {
 
                 // New shot
                 if (shot.ticker == 0) {
+                    if (shot.ticker == 0 && shot.playerId === activePlayerId) {
+                        modAPI._emitLocalPlayerShoot();
+                    }
+                    if (shot.ticker == 0 && shot.playerId !== activePlayerId) {
+                        modAPI._emitPlayerShoot();
+                    }                    
                     const player = playerBarn.getPlayerById(shot.playerId);
 
                     // Play shot sound

--- a/client/src/objects/shot.ts
+++ b/client/src/objects/shot.ts
@@ -116,10 +116,10 @@ export class ShotBarn {
                 // New shot
                 if (shot.ticker == 0) {
                     if (shot.ticker == 0 && shot.playerId === activePlayerId) {
-                        modAPI._emitLocalPlayerShoot();
+                        modAPI._emit("localPlayerShoot", undefined);
                     }
                     if (shot.ticker == 0 && shot.playerId !== activePlayerId) {
-                        modAPI._emitPlayerShoot();
+                        modAPI._emit("playerShoot", undefined);
                     }
                     const player = playerBarn.getPlayerById(shot.playerId);
 


### PR DESCRIPTION
This PR introduces the **initial V1.0 foundation** of the `survevModAPI`.

The focus of this V1.0 is intentionally conservative and limited

- `on*` **hooks** for observing and running code upon game / player events.
- `get*` **hooks** for querying game state (completely read only).
- **No** `set*` **hooks for now**

The absence of `set*` hooks is intentional.

The goal of this PR is meant to establish a stable, well documented, observation layer first, and gathering maintainer feedback before committing to any API hooks which modify game behavior or state

Now as for the motivation behind this.

Historically, mods for survev.io have relied on monkeypatching or full code replacement. While powerful, these approaches are brittle and prone to breaking across updates. This API aims to replace that with a stable interface, starting with safe primitives that wont lock the project into hard-to-reverse decisions.

An additional benefit of providing a well-defined modding sandbox is that it gives mod authors a legitimate and supported path for extending the game, reducing the need to learn invasive techniques such as monkeypatching or code replacement for common use cases.

Once this foundation is agreed upon, mutation hooks can be discussed and designed collaboratively between maintainers and mod authors.

To recap this PR includes

- Initial `on*` callback hooks
- Initial `get*` query hooks
- Complete documentation and examples of use
- A versioned changelog

Any feedback is very welcome and appreciated.