### PR TITLE
fix: further preventing Revivify abuse

### DIFF
--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -2774,8 +2774,8 @@ export class Player extends BaseGameObject {
         this.boost = 0;
         this.health = 100;
 
-        if (this.game.gas.currentRad <= 0.1) {
-            this.health = 50;
+        if (this.game.gas.isInGas(this.pos)) {
+            this.health = 80;
         }
 
         this.animType = GameConfig.Anim.None;


### PR DESCRIPTION
The current implementation of Revivify still allows for abuse: as long as the safe zone radius is not 0, the Revivify player can simply keep stormcamping and get off one last Revive before the final zone. Right before the final safe zone closes, the Revivify player can knock themselves down and gain 100 downed HP instead of 50 downed HP, giving them an extra ~20 seconds of life.

Anecdotes of Revivify abuse are documented (I assume) in the following links:
https://discord.com/channels/1407084649343352852/1470522154029420574
https://discord.com/channels/1407084649343352852/1460444622622032086/1467975210266267851

My fix:
By forcing anyone who is downed by the storm to start with 80 downed HP instead of 100 downed HP, the Revivify players will be unable to stormcamp for the last 4 stages of the storm, instead of being able to stormcamp through almost every stage and get a shot at winning in the final stage. Although this will harm downed players who get knocked out by the storm, I realistically don't see this being that impactful unless it is in 50v50.

Alternatively, you could just make the final few stages of the storm make everyone start with lower downed HP, instead of every stage. Either method is more effective than the current implementation, though.