### PR TITLE
refactor: rename armorPiercing and armorPlated properties to  canBreakReinforced and isReinforced

### DIFF
--- a/server/src/game/objects/obstacle.ts
+++ b/server/src/game/objects/obstacle.ts
@@ -366,21 +366,21 @@ export class Obstacle extends BaseGameObject {
         if (this.health === 0 || !this.destructible) return;
 
         if (params.damageType === DamageType.Player) {
-            let armorPiercing = false;
+            let canBreakReinforced = false;
             let stonePiercing = false;
 
             if (params.gameSourceType) {
                 const sourceDef = GameObjectDefs[params.gameSourceType] as
                     | {
-                          armorPiercing?: boolean;
+                          canBreakReinforced?: boolean;
                           stonePiercing?: boolean;
                       }
                     | undefined;
-                armorPiercing = sourceDef?.armorPiercing ?? false;
+                canBreakReinforced = sourceDef?.canBreakReinforced ?? false;
                 stonePiercing = sourceDef?.stonePiercing ?? false;
             }
 
-            if (def.armorPlated && !armorPiercing) return;
+            if (def.isReinforced && !canBreakReinforced) return;
             if (def.stonePlated && !stonePiercing) return;
         }
 

--- a/shared/defs/gameObjects/meleeDefs.ts
+++ b/shared/defs/gameObjects/meleeDefs.ts
@@ -62,7 +62,7 @@ export interface MeleeDef {
             p1: Vec2;
         };
     };
-    armorPiercing?: boolean;
+    canBreakReinforced?: boolean;
     stonePiercing?: boolean;
 }
 
@@ -504,7 +504,7 @@ const BaseDefs: Record<string, MeleeDef> = {
         name: "Wood Axe",
         type: "melee",
         quality: 0,
-        armorPiercing: true,
+        canBreakReinforced: true,
         autoAttack: false,
         switchDelay: 0.25,
         damage: 36,
@@ -559,7 +559,7 @@ const BaseDefs: Record<string, MeleeDef> = {
         name: "Fire Axe",
         type: "melee",
         quality: 1,
-        armorPiercing: true,
+        canBreakReinforced: true,
         autoAttack: false,
         switchDelay: 0.25,
         damage: 44,
@@ -614,7 +614,7 @@ const BaseDefs: Record<string, MeleeDef> = {
         name: "Katana",
         type: "melee",
         quality: 0,
-        armorPiercing: true,
+        canBreakReinforced: true,
         cleave: true,
         autoAttack: false,
         switchDelay: 0.25,
@@ -670,7 +670,7 @@ const BaseDefs: Record<string, MeleeDef> = {
         name: "Naginata",
         type: "melee",
         quality: 1,
-        armorPiercing: true,
+        canBreakReinforced: true,
         cleave: true,
         autoAttack: false,
         switchDelay: 0.25,
@@ -726,7 +726,7 @@ const BaseDefs: Record<string, MeleeDef> = {
         name: "Stone Hammer",
         type: "melee",
         quality: 1,
-        armorPiercing: true,
+        canBreakReinforced: true,
         stonePiercing: true,
         autoAttack: false,
         switchDelay: 0.25,
@@ -782,7 +782,7 @@ const BaseDefs: Record<string, MeleeDef> = {
         name: "Ice Axe",
         type: "melee",
         quality: 1,
-        armorPiercing: true,
+        canBreakReinforced: true,
         stonePiercing: true,
         autoAttack: false,
         switchDelay: 0.25,

--- a/shared/defs/mapObjectDefs.ts
+++ b/shared/defs/mapObjectDefs.ts
@@ -10517,7 +10517,7 @@ export const MapObjectDefs: Record<string, MapObjectDef> = {
     crate_04: createCrate({
         health: 225,
         destructible: true,
-        armorPlated: true,
+        isReinforced: true,
         hitParticle: "greenChip",
         loot: [tierLoot("tier_ammo_crate", 1, 1)],
         map: { display: true, color: 0x537054, scale: 0.875 },
@@ -10544,7 +10544,7 @@ export const MapObjectDefs: Record<string, MapObjectDef> = {
         collision: collider.createAabbExtents(v2.create(0, 0), v2.create(2.25, 1.1)),
         health: 175,
         destructible: true,
-        armorPlated: true,
+        isReinforced: true,
         hitParticle: "greenChip",
         loot: [tierLoot("tier_ammo", 1, 1)],
         map: { display: false },

--- a/shared/defs/types/obstacle.ts
+++ b/shared/defs/types/obstacle.ts
@@ -110,7 +110,7 @@ export interface ObstacleDef {
     swapWeaponOnDestroy?: boolean;
     regrow?: boolean;
     regrowTimer?: number;
-    armorPlated?: boolean;
+    isReinforced?: boolean;
     smartLoot?: boolean;
     createSmoke?: boolean;
     teamId?: number;


### PR DESCRIPTION
Now that AP Rounds exist, I believe that it is extremely misleading for the armorPiercing property in melee weapons to refer to breaking ammo crates. I refactored it to be cratePiercing to better align with how the property pierces ammo crates, not armor.