### PR TITLE
fix: avoid cache expiry update during queries

### DIFF
--- a/server/src/utils/serverHelpers.ts
+++ b/server/src/utils/serverHelpers.ts
@@ -374,7 +374,7 @@ export async function isBehindProxy(ip: string, vpn: 0 | 1 | 2 | 3): Promise<boo
     if (cached && cached.expiresAt > Date.now()) {
         info = cached.info;
     }
-    if (!info) {
+    else {
         try {
             const proxyRes = await proxyCheck.checkIP(ip, {
                 vpn,
@@ -394,16 +394,17 @@ export async function isBehindProxy(ip: string, vpn: 0 | 1 | 2 | 3): Promise<boo
             }
         } catch (error) {
             defaultLogger.error(`Proxycheck error:`, error);
+        }
+
+        if (!info) {
             return false;
         }
+
+        proxyCheckCache.set(key, {
+            info,
+            expiresAt: Date.now() + util.daysToMs(1),
+        });
     }
-    if (!info) {
-        return false;
-    }
-    proxyCheckCache.set(key, {
-        info,
-        expiresAt: Date.now() + util.daysToMs(1),
-    });
 
     return info.proxy === "yes" || info.vpn === "yes";
 }

--- a/server/src/utils/serverHelpers.ts
+++ b/server/src/utils/serverHelpers.ts
@@ -373,8 +373,7 @@ export async function isBehindProxy(ip: string, vpn: 0 | 1 | 2 | 3): Promise<boo
     const cached = proxyCheckCache.get(key);
     if (cached && cached.expiresAt > Date.now()) {
         info = cached.info;
-    }
-    else {
+    } else {
         try {
             const proxyRes = await proxyCheck.checkIP(ip, {
                 vpn,


### PR DESCRIPTION
Fix an issue where cache expiration is updated on each query, causing outdated caches to remain alive indefinitely (unless users inactive for a full day.)