### PR TITLE
fix: make damage to players caused by airdrop destroying objects not …

### DIFF
--- a/server/src/game/objects/airdrop.ts
+++ b/server/src/game/objects/airdrop.ts
@@ -93,7 +93,7 @@ export class Airdrop extends BaseGameObject {
                     }
                     if (coldet.test(collider, this.crateCollision)) {
                         obj.damage({
-                            amount: obj.__type === ObjectType.Player ? 100 : 1e10,
+                            amount: 1e10,
                             damageType: GameConfig.DamageType.Airdrop,
                             dir: "dir" in obj ? obj.dir : v2.create(0, 0),
                         });

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -2853,8 +2853,7 @@ export class Player extends BaseGameObject {
         // ignore armor for gas and bleeding damage
         if (
             params.damageType !== GameConfig.DamageType.Gas &&
-            params.damageType !== GameConfig.DamageType.Bleeding &&
-            params.damageType !== GameConfig.DamageType.Airdrop
+            params.damageType !== GameConfig.DamageType.Bleeding
         ) {
             const gameSourceDef = GameObjectDefs[params.gameSourceType ?? ""];
             let isHeadShot = false;


### PR DESCRIPTION
…ignore perks

This commit ensures that any damage caused indirectly by airdrops (specifically barrel explosions) doesn't ignore perks. This is relevant for Cast Ironskin and Flak Jacket.