### PR TITLE
fix: prevent class pods from completing airdrop quest

### DIFF
--- a/shared/defs/mapObjectDefs.ts
+++ b/shared/defs/mapObjectDefs.ts
@@ -11308,10 +11308,12 @@ export const MapObjectDefs: Record<string, MapObjectDef> = {
         explodeParticle: "airdropCrate02x",
     } as unknown as Partial<ObstacleDef>),
     class_shell_01: createAirdrop({
+        obstacleType: undefined,
         terrain: {
             minDistanceFromSameType: 32,
         },
         collision: collider.createCircle(v2.create(0, 0), 2.25),
+        airdropCrate: false,
         button: {
             useImg: "map-class-shell-01b.img",
             useParticle: "classShell01a",


### PR DESCRIPTION
https://discord.com/channels/1407084649343352852/1505881395514441781

Note that class_shell_03, which refers to the red Cobalt pod, is likely still bugged since it both exists in the Twins bunker and can be summoned by an airdrop. This partial fix aims to prevent class_shell_01, the default Cobalt class pod, from being able to complete quest_airdrop (quest where you open 1 airdrop).