### PR TITLE
Refactor server net code

### DIFF
--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -17,6 +17,7 @@ import { Editor } from "./debug/editor.ts";
 /* STRIP_FROM_PROD_CLIENT:END */
 
 import { GameObjectDefs } from "../../shared/defs/register.ts";
+import { SpectateAction } from "../../shared/net/spectateMsg.ts";
 import { device } from "./device.ts";
 import { EmoteBarn } from "./emote.ts";
 import { errorLogManager } from "./errorLogs.ts";
@@ -98,7 +99,6 @@ export class Game {
     m_playing!: boolean;
     m_gameOver!: boolean;
     m_spectating!: boolean;
-    m_spectateCooldown!: number;
     m_inputMsgTimeout!: number;
     m_prevInputMsg!: net.InputMsg;
     m_playingTicker!: number;
@@ -312,7 +312,6 @@ export class Game {
         this.m_playing = false;
         this.m_gameOver = false;
         this.m_spectating = false;
-        this.m_spectateCooldown = 0;
         this.m_inputMsgTimeout = 0;
         this.m_prevInputMsg = new net.InputMsg();
         this.m_playingTicker = 0;
@@ -715,28 +714,21 @@ export class Game {
             }
         }
 
-        this.m_spectateCooldown -= dt;
-        const specBegin = this.m_uiManager.specBegin;
-        const specNext = (this.m_uiManager.specNext ||= this.m_spectating && this.m_input.keyPressed(Key.Right));
-        const specPrev = (this.m_uiManager.specPrev ||= this.m_spectating && this.m_input.keyPressed(Key.Left));
-        const specForce = this.m_input.keyPressed(Key.Right) || this.m_input.keyPressed(Key.Left);
+        let specAction = this.m_uiManager.specAction;
+        if (specAction === SpectateAction.None && this.m_spectating) {
+            if (this.m_input.keyPressed(Key.Right)) {
+                specAction = SpectateAction.Next;
+            } else if (this.m_input.keyPressed(Key.Left)) {
+                specAction = SpectateAction.Prev;
+            }
+        }
 
-        if (
-            specBegin
-            || (this.m_spectating && this.m_spectateCooldown < 0 && (specNext || specPrev))
-        ) {
-            this.m_spectateCooldown = 1;
-
+        if (specAction !== SpectateAction.None) {
             const specMsg = new net.SpectateMsg();
-            specMsg.specBegin = specBegin;
-            specMsg.specNext = specNext;
-            specMsg.specPrev = specPrev;
-            specMsg.specForce = specForce;
+            specMsg.action = specAction;
             this.m_sendMessage(net.MsgType.Spectate, specMsg, 128);
 
-            this.m_uiManager.specBegin = false;
-            this.m_uiManager.specNext = false;
-            this.m_uiManager.specPrev = false;
+            this.m_uiManager.specAction = SpectateAction.None;
         }
 
         this.m_uiManager.reloadTouched = false;

--- a/client/src/ui/ui.ts
+++ b/client/src/ui/ui.ts
@@ -118,6 +118,7 @@ export class UiManager {
     rightCenter = $("#ui-right-center");
     leaderboardAlive = $("#ui-leaderboard-alive");
     playersAlive = $(".js-ui-players-alive");
+    playersAliveCounter = 0;
     leaderboardAliveFaction = $("#ui-leaderboard-alive-faction");
     playersAliveRed = $(".js-ui-players-alive-red");
     playersAliveBlue = $(".js-ui-players-alive-blue");
@@ -1543,7 +1544,8 @@ export class UiManager {
                 });
             });
             this.statsOptions.append(restartButton);
-            if (gameOver || this.waitingForPlayers) {
+            const alive = this.playersAliveCounter + this.playersAliveRedCounter + this.playersAliveBlueCounter;
+            if (gameOver || alive === 0) {
                 restartButton.css({
                     width: device.uiLayout != device.UiLayout.Sm || device.tablet
                         ? 225
@@ -1819,6 +1821,7 @@ export class UiManager {
 
     updatePlayersAlive(alive: number) {
         this.playersAlive.html(alive);
+        this.playersAliveCounter = alive;
 
         this.leaderboardAlive.css("display", "block");
         this.leaderboardAliveFaction.css("display", "none");

--- a/client/src/ui/ui.ts
+++ b/client/src/ui/ui.ts
@@ -7,6 +7,7 @@ import type { MapDef } from "../../../shared/defs/mapDefs.ts";
 import { GameObjectDefs } from "../../../shared/defs/register.ts";
 import { Action, GameConfig, GasMode, TeamMode } from "../../../shared/gameConfig.ts";
 import type { PlayerStatsMsg } from "../../../shared/net/playerStatsMsg.ts";
+import { SpectateAction } from "../../../shared/net/spectateMsg.ts";
 import type { MapIndicator, PlayerStatus } from "../../../shared/net/updateMsg.ts";
 import { coldet } from "../../../shared/utils/coldet.ts";
 import { math } from "../../../shared/utils/math.ts";
@@ -164,9 +165,7 @@ export class UiManager {
     resumeButton = $("#btn-game-resume");
 
     specStatsButton = $("#btn-spectate-view-stats");
-    specBegin = false;
-    specNext = false;
-    specPrev = false;
+    specAction = SpectateAction.None;
     specNextButton = $("#btn-spectate-next-player");
     specPrevButton = $("#btn-spectate-prev-player");
 
@@ -381,10 +380,10 @@ export class UiManager {
         });
 
         this.specNextButton.on("click", () => {
-            this.specNext = true;
+            this.specAction = SpectateAction.Next;
         });
         this.specPrevButton.on("click", () => {
-            this.specPrev = true;
+            this.specAction = SpectateAction.Prev;
         });
 
         // Touch specific buttons
@@ -1289,7 +1288,7 @@ export class UiManager {
     }
 
     beginSpectating() {
-        this.specBegin = true;
+        this.specAction = SpectateAction.Begin;
     }
 
     hideStats() {

--- a/server/src/game/client.ts
+++ b/server/src/game/client.ts
@@ -470,7 +470,7 @@ export class Client {
         }
         const rect = collider.createAabbExtents(player.pos, v2.create(width, height));
 
-        const newVisibleObjects = game.grid.intersectColliderSet(rect);
+        const newVisibleObjects = game.grid.intersectAABBSet(rect);
         // client crashes if active player is not visible
         // so make sure its always added to visible objects
         newVisibleObjects.add(player);

--- a/server/src/game/client.ts
+++ b/server/src/game/client.ts
@@ -1,0 +1,804 @@
+import type { EmoteDef } from "../../../shared/defs/gameObjects/emoteDefs.ts";
+import { GameObjectDefs } from "../../../shared/defs/register.ts";
+import { GameConfig } from "../../../shared/gameConfig.ts";
+import * as net from "../../../shared/net/net.ts";
+import { SpectateAction } from "../../../shared/net/spectateMsg.ts";
+import type { Emote, GroupStatus } from "../../../shared/net/updateMsg.ts";
+import { coldet } from "../../../shared/utils/coldet.ts";
+import { collider } from "../../../shared/utils/collider.ts";
+import { math } from "../../../shared/utils/math.ts";
+import { util } from "../../../shared/utils/util.ts";
+import { v2 } from "../../../shared/utils/v2.ts";
+import { Config } from "../config.ts";
+
+import type { Game } from "./game.ts";
+import type { GameObject } from "./objects/gameObject.ts";
+import type { MapIndicator } from "./objects/mapIndicator.ts";
+import type { Player } from "./objects/player.ts";
+import type { ClientSocket } from "./socket.ts";
+
+export class ClientBarn {
+    clients: Client[] = [];
+
+    /**
+     * All msgs created this tick that will be sent to all players
+     * cached in a single stream
+     */
+    msgsToSend = new net.MsgStream(new ArrayBuffer(4096));
+
+    game: Game;
+    constructor(game: Game) {
+        this.game = game;
+    }
+
+    update(dt: number) {
+        for (let i = 0; i < this.clients.length; i++) {
+            this.clients[i].update(dt);
+        }
+    }
+
+    sendMsgs() {
+        for (let i = 0; i < this.clients.length; i++) {
+            const client = this.clients[i];
+            if (client.socket.closed()) continue;
+            client.sendMsgs();
+        }
+    }
+
+    flush() {
+        this.msgsToSend.stream.index = 0;
+    }
+
+    addClientWithPlayer(socket: ClientSocket<Client | undefined>, joinMsg: net.JoinMsg) {
+        const joinData = this.game.joinTokens.get(joinMsg.matchPriv);
+
+        if (!joinData || joinData.expiresAt < Date.now()) {
+            this.game.logger.warn("Client tried to join without or with expired join token");
+            socket.close();
+            if (joinData) {
+                this.game.joinTokens.delete(joinMsg.matchPriv);
+            }
+            return;
+        }
+        this.game.joinTokens.delete(joinMsg.matchPriv);
+
+        if (Config.rateLimitsEnabled) {
+            const count = this.clients.filter(
+                (c) => {
+                    return c.ip === socket.ip()
+                        || c.findGameIp == joinData.findGameIp
+                        || (joinData.userId !== null && c.userId === joinData.userId);
+                },
+            );
+            if (count.length >= 5) {
+                socket.closeWithReason("rate_limited");
+                return;
+            }
+        }
+
+        const client = new Client(this.game, socket, joinData.userId, joinData.findGameIp);
+        this.clients.push(client);
+
+        const player = this.game.playerBarn.addPlayer(client, joinMsg, joinData);
+        client.player = player;
+
+        return client;
+    }
+
+    deserializeMsg(buff: ArrayBuffer): {
+        type: net.MsgType;
+        msg: net.AbstractMsg | undefined;
+        error?: string;
+    } {
+        const msgStream = new net.MsgStream(buff);
+        const stream = msgStream.stream;
+
+        const type = msgStream.deserializeMsgType();
+
+        let msg:
+            | net.JoinMsg
+            | net.InputMsg
+            | net.EmoteMsg
+            | net.DropItemMsg
+            | net.SpectateMsg
+            | net.PerkModeRoleSelectMsg
+            | net.EditMsg
+            | undefined = undefined;
+
+        switch (type) {
+            case net.MsgType.Join: {
+                // read protocol version outside of JoinMsg
+                // reason: if theres a protocol change in JoinMsg it will fail to deserialize the entire msg
+                // and won't give the proper invalid-protocol error
+                // so we read it before deserializing the msg to avoid it throwing and giving the wrong error
+
+                const oldIdx = stream.index;
+                const protocol = stream.readUint32();
+
+                if (protocol !== GameConfig.protocolVersion) {
+                    return {
+                        type: net.MsgType.Join,
+                        msg: undefined,
+                        error: "index-invalid-protocol",
+                    };
+                }
+                stream.index = oldIdx;
+
+                msg = new net.JoinMsg();
+                msg.deserialize(stream);
+                break;
+            }
+            case net.MsgType.Input: {
+                msg = new net.InputMsg();
+                msg.deserialize(stream);
+                break;
+            }
+            case net.MsgType.Emote:
+                msg = new net.EmoteMsg();
+                msg.deserialize(stream);
+                break;
+            case net.MsgType.DropItem:
+                msg = new net.DropItemMsg();
+                msg.deserialize(stream);
+                break;
+            case net.MsgType.Spectate:
+                msg = new net.SpectateMsg();
+                msg.deserialize(stream);
+                break;
+            case net.MsgType.PerkModeRoleSelect:
+                msg = new net.PerkModeRoleSelectMsg();
+                msg.deserialize(stream);
+                break;
+            case net.MsgType.Edit:
+                if (!Config.debug.allowEditMsg) break;
+                msg = new net.EditMsg();
+                msg.deserialize(stream);
+                break;
+        }
+
+        return {
+            type,
+            msg,
+        };
+    }
+
+    handleMsg(buff: ArrayBuffer | Buffer, socket: ClientSocket<Client | undefined>) {
+        if (!(buff instanceof ArrayBuffer)) return;
+
+        let client = socket.getUserData();
+
+        let msg: net.AbstractMsg | undefined = undefined;
+        let type = net.MsgType.None;
+        let error: string | undefined;
+
+        try {
+            const deserialized = this.deserializeMsg(buff);
+            msg = deserialized.msg;
+            type = deserialized.type;
+            error = deserialized.error;
+        } catch (err) {
+            this.game.logger.error(
+                "Failed to deserialize msg: ",
+                err,
+                "msg buffer: ",
+                // JSON.stringify doesn't work on buffers, so need to convert to an Uint8Array first
+                // and then to a regular array... 😭
+                // the slice is to make sure it doesn't overflow the error webhook
+                JSON.stringify([...new Uint8Array(buff.slice(0, 255))]),
+            );
+            if (client) {
+                client.disconnect();
+            } else {
+                socket.close();
+            }
+            return;
+        }
+
+        if (error) {
+            this.game.logger.warn("Disconnecting client because of packet error:", error);
+            if (client) {
+                client.disconnect(error);
+            } else {
+                socket.close();
+            }
+            return;
+        }
+
+        if (!msg) return;
+
+        if (type === net.MsgType.Join && !client) {
+            client = this.game.clientBarn.addClientWithPlayer(socket, msg as net.JoinMsg);
+            return;
+        }
+
+        if (!client) {
+            this.game.logger.warn("No client found and we didn't receive a JoinMsg, closing socket");
+            socket.close();
+            return;
+        }
+
+        if (socket.closed()) {
+            return;
+        }
+        client.handleMsg(type, msg);
+    }
+
+    handleSocketClose(socket: ClientSocket<Client | undefined>) {
+        const client = socket.getUserData();
+        if (!client) return;
+        client.spectating = undefined;
+        client.disconnected = true;
+        util.removeFrom(this.clients, client);
+
+        if (!client.player) return;
+        const player = client.player;
+        this.game.logger.info(`"${player.name}" left`);
+
+        // reset direction and movement
+        player.dirNew = v2.create(1, 0);
+        player.moveLeft = false;
+        player.moveRight = false;
+        player.moveUp = false;
+        player.moveDown = false;
+        player.shootHold = false;
+        player.touchMoveActive = false;
+
+        player.setPartDirty();
+        player.group?.checkPlayers();
+        player.setGroupStatuses();
+        player.questManager.flushProgress();
+
+        if (player.canDespawn()) {
+            player.game.playerBarn.removePlayer(player);
+        }
+    }
+
+    broadcastMsg(type: net.MsgType, msg: net.Msg) {
+        this.msgsToSend.serializeMsg(type, msg);
+    }
+}
+
+export class Client {
+    game: Game;
+    socket: ClientSocket<Client>;
+
+    disconnected = false;
+
+    userId: string | null = null;
+    ip: string;
+    // see comment on server/src/api/schema.ts
+    // about logging find_game IP's
+    findGameIp: string;
+
+    lastPlayerId = 0;
+    player?: Player = undefined;
+
+    /** true when player starts spectating new player, only stays true for that given tick */
+    startedSpectating: boolean = false;
+
+    private _spectating?: Player;
+
+    get spectating(): Player | undefined {
+        return this._spectating;
+    }
+
+    set spectating(player: Player | undefined) {
+        if (player && player === this.player) {
+            throw new Error(
+                `Player ${player.name} tried spectate themselves (how tf did this happen?)`,
+            );
+        }
+        if (this._spectating === player) return;
+
+        if (this._spectating) {
+            this._spectating.spectators.delete(this);
+            this._spectating.recalculateSpectatorCount();
+        }
+        if (player) {
+            player.spectators.add(this);
+            player.recalculateSpectatorCount();
+        }
+
+        this._spectating = player;
+        this.startedSpectating = true;
+    }
+
+    private _specCooldown = 0;
+    private _specAction = SpectateAction.None;
+    specAnon = false;
+
+    spectateNewPlayerTicker = 0;
+
+    private _firstUpdate = true;
+    visibleObjects = new Set<GameObject>();
+    visibleMapIndicators = new Set<MapIndicator>();
+
+    // zoom used for the area in which the server will send objects to the client
+    private _cullingZoom = GameConfig.scopeZoomRadius.desktop["1xscope"];
+
+    portrait = false;
+    private _cullingPortrait = false;
+    private _cullingPortraitTicker = 0;
+
+    msgStream = new net.MsgStream(new ArrayBuffer(65536));
+    msgsToSend: Array<{ type: number; msg: net.Msg }> = [];
+
+    ack = 0;
+
+    constructor(
+        game: Game,
+        socket: ClientSocket<Client | undefined>,
+        userId: string | null,
+        findGameIp: string,
+    ) {
+        this.userId = userId;
+        this.ip = socket.ip();
+        this.findGameIp = findGameIp;
+        this.game = game;
+        socket.setUserData(this);
+        this.socket = socket as ClientSocket<Client>;
+    }
+
+    sendMsg(type: net.MsgType, msg: net.AbstractMsg): void {
+        this.msgsToSend.push({ type, msg });
+    }
+
+    sendInstantMsg(type: net.MsgType, msg: net.AbstractMsg, bytes = 128): void {
+        const stream = new net.MsgStream(new ArrayBuffer(bytes));
+        stream.serializeMsg(type, msg);
+        this.sendData(stream.getBuffer());
+    }
+
+    sendData(buffer: Uint8Array<ArrayBuffer>): void {
+        this.socket.send(buffer);
+    }
+
+    disconnect(reason?: string) {
+        if (reason) {
+            this.socket.closeWithReason(reason);
+        } else {
+            this.socket.close();
+        }
+    }
+
+    update(dt: number) {
+        if (this.spectating) {
+            let newPlayerToSpectate: Player | undefined = undefined;
+
+            // switch to a new spectator after 2 seconds if the player we are spectating has died
+            if (this.spectating.dead) {
+                this.spectateNewPlayerTicker += dt;
+                if (this.spectateNewPlayerTicker > 2) {
+                    newPlayerToSpectate = this.getNewPlayerToSpectate();
+                    this.spectateNewPlayerTicker = 0;
+                }
+            } else {
+                this.spectateNewPlayerTicker = 0;
+            }
+
+            // spectate prev/next keybind logic
+            this._specCooldown -= dt;
+            if (this._specCooldown <= 0 && this._specAction !== SpectateAction.None) {
+                const nextOrPrev = this._specAction === SpectateAction.Next ? +1 : -1;
+                const spectatablePlayers = this.getSpectablePlayers(true);
+
+                newPlayerToSpectate = util.wrappedArrayIndex(
+                    spectatablePlayers,
+                    spectatablePlayers.indexOf(this.spectating!) + nextOrPrev,
+                );
+
+                // when spectating teammates we can have a lower cooldown
+                // since it cant be abused to know players positions
+                this._specCooldown = this.shouldSpectateTeam() ? 0.1 : 1;
+                this._specAction = SpectateAction.None;
+            }
+
+            if (newPlayerToSpectate) {
+                this.spectating = newPlayerToSpectate;
+            }
+        }
+
+        const targetZoom = this.spectating?.zoom ?? this.player?.zoom ?? 1;
+
+        // lerp towards the target zoom
+        if (math.eqAbs(this._cullingZoom, targetZoom, 0.1)) {
+            this._cullingZoom = targetZoom;
+        } else {
+            this._cullingZoom = math.lerp(dt * 4, this._cullingZoom, targetZoom);
+        }
+
+        if (this.portrait !== this._cullingPortrait) {
+            this._cullingPortraitTicker -= dt;
+            if (this._cullingPortraitTicker <= 0) {
+                this._cullingPortrait = this.portrait;
+            }
+        }
+    }
+
+    sendMsgs(): void {
+        const msgStream = this.msgStream;
+        const game = this.game;
+        const playerBarn = game.playerBarn;
+        msgStream.stream.index = 0;
+
+        const player = this.spectating ?? this.player;
+        if (!player) return;
+
+        if (this._firstUpdate) {
+            const joinedMsg = new net.JoinedMsg();
+            joinedMsg.teamMode = this.game.teamMode;
+            joinedMsg.playerId = this.player?.__id ?? 0;
+            joinedMsg.started = game.started;
+            joinedMsg.teamMode = game.teamMode;
+            if (this.player) {
+                joinedMsg.emotes = this.player.loadout.emotes;
+            }
+            msgStream.serializeMsg(net.MsgType.Joined, joinedMsg);
+
+            const mapStream = game.map.mapStream.stream;
+
+            msgStream.stream.writeBytes(mapStream, 0, mapStream.byteIndex);
+        }
+
+        if (playerBarn.aliveCountDirty || this._firstUpdate) {
+            const aliveMsg = new net.AliveCountsMsg();
+            this.game.modeManager.updateAliveCounts(aliveMsg.teamAliveCounts);
+            msgStream.serializeMsg(net.MsgType.AliveCounts, aliveMsg);
+        }
+
+        const updateMsg = new net.UpdateMsg();
+        updateMsg.ack = this.ack;
+
+        if (game.gas.dirty || this._firstUpdate) {
+            updateMsg.gasDirty = true;
+            updateMsg.gasData = game.gas;
+        }
+
+        if (game.gas.timeDirty || this._firstUpdate) {
+            updateMsg.gasTDirty = true;
+            updateMsg.gasT = game.gas.gasT;
+        }
+
+        const radius = this._cullingZoom + 4;
+        let width = this._cullingZoom + 4;
+        // client zoom tries to keep a 16/9 aspect ratio, mirror it here
+        let height = width / (16 / 9);
+        if (this._cullingPortrait) {
+            let tmp = width;
+            width = height;
+            height = tmp;
+        }
+        const rect = collider.createAabbExtents(player.pos, v2.create(width, height));
+
+        const newVisibleObjects = game.grid.intersectColliderSet(rect);
+        // client crashes if active player is not visible
+        // so make sure its always added to visible objects
+        newVisibleObjects.add(player);
+
+        for (const obj of this.visibleObjects) {
+            if (!newVisibleObjects.has(obj)) {
+                updateMsg.delObjIds.push(obj.__id);
+            }
+        }
+
+        for (const obj of newVisibleObjects) {
+            if (
+                !this.visibleObjects.has(obj)
+                || game.objectRegister.dirtyFull[obj.__id]
+            ) {
+                updateMsg.fullObjects.push(obj);
+            } else if (game.objectRegister.dirtyPart[obj.__id]) {
+                updateMsg.partObjects.push(obj);
+            }
+        }
+
+        this.visibleObjects = newVisibleObjects;
+
+        updateMsg.activePlayerId = player.__id;
+        if (this.startedSpectating) {
+            updateMsg.activePlayerIdDirty = true;
+
+            // build the active player data object manually
+            // To avoid setting the spectating player fields to dirty
+            updateMsg.activePlayerData = {
+                healthDirty: true,
+                health: player.health,
+                boostDirty: true,
+                boost: player.boost,
+                zoomDirty: true,
+                zoom: player.zoom,
+                actionDirty: true,
+                action: player.action,
+                inventoryDirty: true,
+                inventory: player.inventory,
+                scope: player.scope,
+                weapsDirty: true,
+                curWeapIdx: player.curWeapIdx,
+                weapons: player.weapons,
+                spectatorCountDirty: true,
+                spectatorCount: player.spectatorCount,
+            };
+            this.startedSpectating = false;
+        } else {
+            updateMsg.activePlayerIdDirty = player.__id !== this.lastPlayerId;
+            updateMsg.activePlayerData = player;
+        }
+        this.lastPlayerId = player.__id;
+
+        updateMsg.playerInfos = this._firstUpdate
+            ? playerBarn.players
+            : playerBarn.newPlayers;
+
+        updateMsg.deletedPlayerIds = playerBarn.deletedPlayers;
+
+        if (playerBarn.playerStatusTicker > playerBarn.playerStatusRate) {
+            let statuses = player.getPlayerStatus();
+            updateMsg.playerStatus = statuses;
+            updateMsg.playerStatusDirty = true;
+        }
+
+        if (player.groupStatusDirty) {
+            const teamPlayers = player.group!.players;
+
+            let statuses: GroupStatus[] = [];
+            for (const p of teamPlayers) {
+                statuses.push({
+                    health: p.health,
+                    disconnected: p.disconnected,
+                });
+            }
+            updateMsg.groupStatus = statuses;
+            updateMsg.groupStatusDirty = true;
+        }
+
+        const shouldSendEmote = (emote: Emote) => {
+            const emotePlayer = game.objectRegister.getById(emote.playerId) as
+                | Player
+                | undefined;
+
+            const emoteDef = GameObjectDefs.typeToDef(emote.type);
+
+            if (emotePlayer) {
+                if (!emote.isPing && !this.visibleObjects.has(emotePlayer)) {
+                    return false;
+                }
+
+                // regular emotes: always send if visible
+                if (!emote.isPing && !(emoteDef as EmoteDef).teamOnly) {
+                    return true;
+                }
+
+                // part of the same group
+                if (emotePlayer?.groupId === player.groupId) {
+                    return true;
+                }
+
+                // part of the same team
+                if (emotePlayer?.teamId === player.teamId && !emote.isPing) {
+                    return true;
+                }
+
+                // faction team leader
+                if (
+                    (emotePlayer.role === "leader"
+                        || emotePlayer.role === "captain"
+                        || emotePlayer.role === "last_man")
+                    && emotePlayer.teamId === player.teamId
+                ) {
+                    return true;
+                }
+            }
+
+            // always send map events pings
+            if (emote.isPing && emoteDef.type === "ping" && emoteDef.mapEvent) {
+                return true;
+            }
+
+            return false;
+        };
+
+        for (let i = 0; i < playerBarn.emotes.length; i++) {
+            const emote = playerBarn.emotes[i];
+            if (shouldSendEmote(emote)) {
+                updateMsg.emotes.push(emote);
+            }
+        }
+
+        const extendedRadius = 1.1 * radius;
+        const radiusSquared = extendedRadius * extendedRadius;
+
+        const bullets = game.bulletBarn.newBullets;
+        for (let i = 0; i < bullets.length; i++) {
+            const bullet = bullets[i];
+            if (
+                v2.lengthSqr(v2.sub(bullet.pos, player.pos)) < radiusSquared
+                || v2.lengthSqr(v2.sub(bullet.clientEndPos, player.pos)) < radiusSquared
+                || coldet.intersectSegmentCircle(
+                    bullet.pos,
+                    bullet.clientEndPos,
+                    player.pos,
+                    extendedRadius,
+                )
+            ) {
+                updateMsg.bullets.push(bullet);
+            }
+        }
+
+        for (let i = 0; i < game.explosionBarn.newExplosions.length; i++) {
+            const explosion = game.explosionBarn.newExplosions[i];
+            const rad = explosion.rad + extendedRadius;
+            if (v2.lengthSqr(v2.sub(explosion.pos, player.pos)) < rad * rad) {
+                updateMsg.explosions.push(explosion);
+            }
+        }
+
+        const planes = this.game.planeBarn.planes;
+        for (let i = 0; i < planes.length; i++) {
+            const plane = planes[i];
+            if (
+                coldet.testCircleAabb(plane.pos, plane.rad, rect.min, rect.max)
+                && coldet.testPointAabb(
+                    plane.pos,
+                    this.game.planeBarn.planeBounds.min,
+                    this.game.planeBarn.planeBounds.max,
+                )
+            ) {
+                updateMsg.planes.push(plane);
+            }
+        }
+        const newAirstrikeZones = this.game.planeBarn.newAirstrikeZones;
+        for (let i = 0; i < newAirstrikeZones.length; i++) {
+            const zone = newAirstrikeZones[i];
+            updateMsg.airstrikeZones.push(zone);
+        }
+
+        const indicators = this.game.mapIndicatorBarn.mapIndicators;
+        for (let i = 0; i < indicators.length; i++) {
+            const indicator = indicators[i];
+            if (indicator.dirty || !this.visibleMapIndicators.has(indicator)) {
+                updateMsg.mapIndicators.push(indicator);
+                this.visibleMapIndicators.add(indicator);
+            }
+            if (indicator.dead) {
+                this.visibleMapIndicators.delete(indicator);
+            }
+        }
+
+        if (playerBarn.killLeaderDirty || this._firstUpdate) {
+            updateMsg.killLeaderDirty = true;
+            updateMsg.killLeaderId = playerBarn.killLeader?.__id ?? 0;
+            updateMsg.killLeaderKills = playerBarn.killLeader?.kills ?? 0;
+        }
+
+        msgStream.serializeMsg(net.MsgType.Update, updateMsg);
+
+        for (let i = 0; i < this.msgsToSend.length; i++) {
+            const msg = this.msgsToSend[i];
+            msgStream.serializeMsg(msg.type, msg.msg);
+        }
+
+        this.msgsToSend.length = 0;
+
+        const globalMsgStream = this.game.clientBarn.msgsToSend.stream;
+        msgStream.stream.writeBytes(globalMsgStream, 0, globalMsgStream.byteIndex);
+
+        this.sendData(msgStream.getBuffer());
+        this._firstUpdate = false;
+    }
+
+    handleMsg(type: net.MsgType, msg: net.Msg) {
+        const player = this.player;
+        switch (type) {
+            case net.MsgType.Input: {
+                const imsg = msg as net.InputMsg;
+                if (this.portrait != imsg.portrait) {
+                    this._cullingPortraitTicker = 0.5;
+                }
+                this.portrait = imsg.portrait;
+
+                this.ack = imsg.seq;
+
+                if (!player) break;
+                player.handleInput(imsg);
+                break;
+            }
+            case net.MsgType.Emote: {
+                if (!player) break;
+
+                player.emoteFromMsg(msg as net.EmoteMsg);
+                break;
+            }
+            case net.MsgType.DropItem: {
+                if (!player) break;
+
+                player.dropItem(msg as net.DropItemMsg);
+                break;
+            }
+            case net.MsgType.Spectate: {
+                this.handleSpectateMsg(msg as net.SpectateMsg);
+                break;
+            }
+            case net.MsgType.PerkModeRoleSelect: {
+                if (!player) break;
+                player.roleSelect((msg as net.PerkModeRoleSelectMsg).role);
+                break;
+            }
+            case net.MsgType.Edit: {
+                if (!player) break;
+                player.processEditMsg(msg as net.EditMsg);
+                break;
+            }
+        }
+    }
+
+    shouldSpectateTeam() {
+        if (!this.player) return false;
+
+        const team = this.player.team || this.player.group;
+        if (!team) return false;
+
+        return !team.allDeadOrDisconnected;
+    }
+
+    getSpectablePlayers(includeCurrent = false): Player[] {
+        // we want to include the player we are currently spectating
+        // even if they are dead, we only switch to a new player after 2 seconds
+        // and not including it in the list will mess up the index for prev/next keybinds
+        const shouldSpectate = (p: Player) => {
+            if (includeCurrent && p === this.spectating) return true;
+            return !p.dead;
+        };
+
+        if (this.shouldSpectateTeam()) {
+            const team = this.player!.team ?? this.player!.group!;
+
+            const groupId = this.player!.groupId;
+            // put our group first, then sort others by their own group
+            // so on faction mode we start spectating our own group first
+            return team.players.filter(shouldSpectate).toSorted((a, b) => {
+                if (a.groupId === b.groupId) {
+                    return a.matchDataId - b.matchDataId;
+                }
+
+                if (a.groupId === groupId) return -Infinity;
+                if (b.groupId === groupId) return Infinity;
+
+                return a.groupId - b.groupId;
+            });
+        } else if (!this.game.isTeamMode) {
+            return this.game.playerBarn.players.filter(shouldSpectate).toSorted((a, b) => {
+                if (a.groupId === b.groupId) {
+                    return a.matchDataId - b.matchDataId;
+                }
+                return a.groupId - b.groupId;
+            });
+        } else {
+            return this.game.playerBarn.livingPlayers.filter(shouldSpectate);
+        }
+    }
+
+    getNewPlayerToSpectate(): Player {
+        const spectateTeam = this.shouldSpectateTeam();
+        let killer: Player | undefined = undefined;
+        if (this.player && !spectateTeam) {
+            killer = this.player.getAliveKiller();
+        }
+        if (killer) return killer;
+        return this.getSpectablePlayers()[0];
+    }
+
+    handleSpectateMsg(spectateMsg: net.SpectateMsg): void {
+        if (this.player && !this.player.dead) return;
+
+        switch (spectateMsg.action) {
+            case SpectateAction.Begin:
+                if (this.spectating) break;
+                this.spectating = this.getNewPlayerToSpectate();
+                break;
+            case SpectateAction.Next:
+            case SpectateAction.Prev:
+                this._specAction = spectateMsg.action;
+                break;
+        }
+    }
+}

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -1,11 +1,10 @@
-import { GameConfig, TeamMode } from "../../../shared/gameConfig.ts";
-import * as net from "../../../shared/net/net.ts";
+import { TeamMode } from "../../../shared/gameConfig.ts";
 import type { Loadout } from "../../../shared/utils/loadout.ts";
 import { math } from "../../../shared/utils/math.ts";
-import { v2 } from "../../../shared/utils/v2.ts";
 import { Config } from "../config.ts";
 import { ServerLogger } from "../utils/logger.ts";
 import { type FindGamePrivateBody, type ServerGameConfig } from "../utils/types.ts";
+import { ClientBarn } from "./client.ts";
 import { GameModeManager } from "./gameModeManager.ts";
 import { Grid } from "./grid.ts";
 import { GameMap } from "./map.ts";
@@ -19,11 +18,10 @@ import { Gas } from "./objects/gas.ts";
 import { LootBarn } from "./objects/loot.ts";
 import { MapIndicatorBarn } from "./objects/mapIndicator.ts";
 import { PlaneBarn } from "./objects/plane.ts";
-import { Player, PlayerBarn } from "./objects/player.ts";
+import { PlayerBarn } from "./objects/player.ts";
 import { ProjectileBarn } from "./objects/projectile.ts";
 import { SmokeBarn } from "./objects/smoke.ts";
 import { Profiler } from "./profiler.ts";
-import type { ClientSocket } from "./socket.ts";
 
 export interface JoinTokenData {
     expiresAt: number;
@@ -71,21 +69,12 @@ export class Game {
         return this.playerBarn.livingPlayers.length;
     }
 
-    get trueAliveCount(): number {
-        return this.playerBarn.livingPlayers.filter((p) => !p.disconnected).length;
-    }
-
-    /**
-     * All msgs created this tick that will be sent to all players
-     * cached in a single stream
-     */
-    msgsToSend = new net.MsgStream(new ArrayBuffer(4096));
-
     grid: Grid<GameObject>;
     map: GameMap;
     gas: Gas;
     objectRegister: ObjectRegister;
 
+    clientBarn: ClientBarn;
     playerBarn: PlayerBarn;
     lootBarn: LootBarn;
     deadBodyBarn: DeadBodyBarn;
@@ -120,6 +109,7 @@ export class Game {
         this.grid = new Grid(this.map.width, this.map.height);
         this.objectRegister = new ObjectRegister(this.grid);
 
+        this.clientBarn = new ClientBarn(this);
         this.playerBarn = new PlayerBarn(this);
         this.lootBarn = new LootBarn(this);
         this.deadBodyBarn = new DeadBodyBarn(this);
@@ -205,6 +195,10 @@ export class Game {
 
         this.profiler.addSample("players");
         this.playerBarn.update(dt);
+        this.profiler.endSample();
+
+        this.profiler.addSample("clients");
+        this.clientBarn.update(dt);
         this.profiler.endSample();
 
         this.profiler.addSample("map");
@@ -294,11 +288,12 @@ export class Game {
 
         // serialize objects and send msgs
         this.objectRegister.serializeObjs();
-        this.playerBarn.sendMsgs();
+        this.clientBarn.sendMsgs();
 
         //
         // reset stuff
         //
+        this.clientBarn.flush();
         this.playerBarn.flush();
         this.lootBarn.flush();
         this.planeBarn.flush();
@@ -308,8 +303,6 @@ export class Game {
         this.explosionBarn.flush();
         this.gas.flush();
         this.mapIndicatorBarn.flush();
-
-        this.msgsToSend.stream.index = 0;
 
         const syncTime = performance.now() - start;
         if (syncTime > 1000) {
@@ -337,189 +330,6 @@ export class Game {
             && !this.over
             && this.startedTime < 60
         );
-    }
-
-    deserializeMsg(buff: ArrayBuffer): {
-        type: net.MsgType;
-        msg: net.AbstractMsg | undefined;
-        error?: string;
-    } {
-        const msgStream = new net.MsgStream(buff);
-        const stream = msgStream.stream;
-
-        const type = msgStream.deserializeMsgType();
-
-        let msg:
-            | net.JoinMsg
-            | net.InputMsg
-            | net.EmoteMsg
-            | net.DropItemMsg
-            | net.SpectateMsg
-            | net.PerkModeRoleSelectMsg
-            | net.EditMsg
-            | undefined = undefined;
-
-        switch (type) {
-            case net.MsgType.Join: {
-                // read protocol version outside of JoinMsg
-                // reason: if theres a protocol change in JoinMsg it will fail to deserialize the entire msg
-                // and won't give the proper invalid-protocol error
-                // so we read it before deserializing the msg to avoid it throwing and giving the wrong error
-
-                const oldIdx = stream.index;
-                const protocol = stream.readUint32();
-
-                if (protocol !== GameConfig.protocolVersion) {
-                    return {
-                        type: net.MsgType.Join,
-                        msg: undefined,
-                        error: "index-invalid-protocol",
-                    };
-                }
-                stream.index = oldIdx;
-
-                msg = new net.JoinMsg();
-                msg.deserialize(stream);
-                break;
-            }
-            case net.MsgType.Input: {
-                msg = new net.InputMsg();
-                msg.deserialize(stream);
-                break;
-            }
-            case net.MsgType.Emote:
-                msg = new net.EmoteMsg();
-                msg.deserialize(stream);
-                break;
-            case net.MsgType.DropItem:
-                msg = new net.DropItemMsg();
-                msg.deserialize(stream);
-                break;
-            case net.MsgType.Spectate:
-                msg = new net.SpectateMsg();
-                msg.deserialize(stream);
-                break;
-            case net.MsgType.PerkModeRoleSelect:
-                msg = new net.PerkModeRoleSelectMsg();
-                msg.deserialize(stream);
-                break;
-            case net.MsgType.Edit:
-                if (!Config.debug.allowEditMsg) break;
-                msg = new net.EditMsg();
-                msg.deserialize(stream);
-                break;
-        }
-
-        return {
-            type,
-            msg,
-        };
-    }
-
-    handleMsg(buff: ArrayBuffer | Buffer, socket: ClientSocket<Player | undefined>) {
-        if (!(buff instanceof ArrayBuffer)) return;
-
-        const player = socket.getUserData();
-
-        let msg: net.AbstractMsg | undefined = undefined;
-        let type = net.MsgType.None;
-        let error: string | undefined;
-
-        try {
-            const deserialized = this.deserializeMsg(buff);
-            msg = deserialized.msg;
-            type = deserialized.type;
-            error = deserialized.error;
-        } catch (err) {
-            this.logger.error(
-                "Failed to deserialize msg: ",
-                err,
-                "msg buffer: ",
-                // JSON.stringify doesn't work on buffers, so need to convert to an Uint8Array first
-                // and then to a regular array... 😭
-                // the slice is to make sure it doesn't overflow the error webhook
-                JSON.stringify([...new Uint8Array(buff.slice(0, 255))]),
-            );
-            if (player) {
-                player.disconnect();
-            } else {
-                socket.close();
-            }
-            return;
-        }
-
-        if (error) {
-            this.logger.warn("Disconnecting player because of packet error:", error);
-            if (player) {
-                player.disconnect();
-            } else {
-                socket.close();
-            }
-            return;
-        }
-
-        if (!msg) return;
-
-        if (type === net.MsgType.Join && !player) {
-            this.playerBarn.addPlayer(socket, msg as net.JoinMsg);
-            return;
-        }
-
-        if (!player) {
-            this.logger.warn("No player found and we didn't receive a JoinMsg, closing socket");
-            socket.close();
-            return;
-        }
-
-        if (player.disconnected) {
-            return;
-        }
-
-        switch (type) {
-            case net.MsgType.Input: {
-                player.handleInput(msg as net.InputMsg);
-                break;
-            }
-            case net.MsgType.Emote: {
-                player.emoteFromMsg(msg as net.EmoteMsg);
-                break;
-            }
-            case net.MsgType.DropItem: {
-                player.dropItem(msg as net.DropItemMsg);
-                break;
-            }
-            case net.MsgType.Spectate: {
-                player.spectate(msg as net.SpectateMsg);
-                break;
-            }
-            case net.MsgType.PerkModeRoleSelect: {
-                player.roleSelect((msg as net.PerkModeRoleSelectMsg).role);
-                break;
-            }
-            case net.MsgType.Edit: {
-                player.processEditMsg(msg as net.EditMsg);
-                break;
-            }
-        }
-    }
-
-    handleSocketClose(socket: ClientSocket<Player | undefined>) {
-        const player = socket.getUserData();
-        if (!player) return;
-        this.logger.info(`"${player.name}" left`);
-        player.questManager.flushProgress();
-        player.disconnected = true;
-        player.group?.checkPlayers();
-        player.spectating = undefined;
-        player.dirNew = v2.create(1, 0);
-        player.setPartDirty();
-        if (player.canDespawn()) {
-            player.game.playerBarn.removePlayer(player);
-        }
-    }
-
-    broadcastMsg(type: net.MsgType, msg: net.Msg) {
-        this.msgsToSend.serializeMsg(type, msg);
     }
 
     checkGameOver() {
@@ -562,10 +372,8 @@ export class Game {
     stop() {
         if (this.stopped) return;
         this.stopped = true;
-        for (const player of this.playerBarn.players) {
-            if (!player.disconnected) {
-                player.disconnect();
-            }
+        for (const client of this.clientBarn.clients) {
+            client.disconnect();
         }
         this.logger.info("Game Ended");
         this.updateData();

--- a/server/src/game/gameModeManager.ts
+++ b/server/src/game/gameModeManager.ts
@@ -263,42 +263,6 @@ export class GameModeManager {
         }
     }
 
-    /**
-     * gives all the players spectating the player who died a new player to spectate
-     * @param player player who died
-     */
-    assignNewSpectate(player: Player): void {
-        // This method doesn't use a mode switchcase like all the other methods in this class,
-        // as the spectate logic is identitical with the sole exception of narrowing random players
-        // in 50v50: random players spectated in 50v50 should be on the same team as the spectator.
-
-        // If there are no spectators, we have no need to run any logic.
-        if (player.spectatorCount === 0) return;
-
-        // Priority list of spectate targets.
-        const spectateTargets = [
-            player.group?.randomPlayer(), // undefined if no player to choose
-            player.team?.randomPlayer(), // undefined if no player to choose
-            player.getAliveKiller(),
-            player.game.playerBarn.randomPlayer(),
-        ];
-
-        const playerToSpec = spectateTargets.filter((x) => x !== undefined).shift();
-        for (const spectator of player.spectators) {
-            // If all group members have died, they need to be sent a game over message instead.
-            if (
-                player.group
-                && player.group.allDeadOrDisconnected
-                && player.group.players.includes(spectator)
-            ) {
-                continue;
-            }
-
-            // Set remaining spectators to new player.
-            spectator.spectating = playerToSpec;
-        }
-    }
-
     handlePlayerDeath(player: Player, params: DamageParams): void {
         if (this.isSolo) {
             player.kill(params);

--- a/server/src/game/gameModeManager.ts
+++ b/server/src/game/gameModeManager.ts
@@ -125,8 +125,10 @@ export class GameModeManager {
             }
             case GameMode.Team: {
                 const winner = this.game.playerBarn.getAliveGroups()[0];
-                for (const player of winner.getAlivePlayers()) {
-                    player.addGameOverMsg(winner.id);
+                for (const player of winner.players) {
+                    if (!player.disconnected && !player.dead) {
+                        player.addGameOverMsg(winner.id);
+                    }
                 }
                 break;
             }

--- a/server/src/game/gameProcess.ts
+++ b/server/src/game/gameProcess.ts
@@ -5,9 +5,9 @@ import { Config } from "../config.ts";
 import { apiPrivateRouter } from "../utils/apiRouter.ts";
 import { logErrorToWebhook } from "../utils/logger.ts";
 import type { SaveGameBody } from "../utils/types.ts";
+import type { Client } from "./client.ts";
 import { Game } from "./game.ts";
 import { type ProcessMsg, ProcessMsgType } from "./ipcTypes.ts";
-import type { Player } from "./objects/player.ts";
 import { ClientSocket } from "./socket.ts";
 
 let game: ServerGame | undefined;
@@ -92,8 +92,8 @@ class ServerGame extends Game {
                 mapSeed: this.map.seed,
                 killedIds: player.killedIds,
                 rank: rank,
-                ip: player.ip,
-                findGameIp: player.findGameIp,
+                ip: player.client.ip,
+                findGameIp: player.client.findGameIp,
                 role: player.role,
             };
         });
@@ -151,11 +151,11 @@ const socketMsgs: Array<{
 
 let lastMsgTime = Date.now();
 
-const socketIdToSocket = new Map<string, ProcessSocket<Player | undefined>>();
+const socketIdToSocket = new Map<string, ProcessSocket<Client | undefined>>();
 class ProcessSocket<T> extends ClientSocket<T> {
     private _id: string;
     private _ip: string;
-    private _closed = false;
+    _closed = false;
     constructor(id: string, ip: string) {
         super();
         this._id = id;
@@ -189,6 +189,7 @@ class ProcessSocket<T> extends ClientSocket<T> {
     }
 
     closeWithReason(reason: string): void {
+        this._closed = true;
         sendMsg({
             type: ProcessMsgType.SocketClose,
             socketId: this._id,
@@ -217,18 +218,19 @@ process.on("message", (msg: ProcessMsg) => {
             game.addJoinTokens(msg.tokens, msg.autoFill);
             break;
         case ProcessMsgType.SocketOpen: {
-            const socket = new ProcessSocket<Player | undefined>(msg.socketId, msg.ip);
+            const socket = new ProcessSocket<Client | undefined>(msg.socketId, msg.ip);
             socketIdToSocket.set(msg.socketId, socket);
             break;
         }
         case ProcessMsgType.ClientSocketMsg: {
             let socket = socketIdToSocket.get(msg.socketId)!;
-            game.handleMsg(msg.data as ArrayBuffer, socket);
+            game.clientBarn.handleMsg(msg.data as ArrayBuffer, socket);
             break;
         }
         case ProcessMsgType.SocketClose: {
             const socket = socketIdToSocket.get(msg.socketId)!;
-            game.handleSocketClose(socket);
+            socket._closed = true;
+            game.clientBarn.handleSocketClose(socket);
             socketIdToSocket.delete(msg.socketId);
             break;
         }

--- a/server/src/game/grid.ts
+++ b/server/src/game/grid.ts
@@ -132,16 +132,7 @@ export class Grid<T extends GameObject = GameObject> {
         return objects;
     }
 
-    /**
-     * Get all objects near this collider
-     * This transforms the collider into a rectangle
-     * and gets all objects intersecting it after rounding it to grid cells
-     * @param coll The collider
-     * @return A set with the objects near this collider
-     */
-    intersectColliderSet(coll: Collider): Set<T> {
-        const aabb = collider.toAabb(coll);
-
+    intersectAABBSet(aabb: AABB): Set<T> {
         const min = this._roundToCells(aabb.min);
         const max = this._roundToCells(aabb.max);
 

--- a/server/src/game/group.ts
+++ b/server/src/game/group.ts
@@ -22,14 +22,6 @@ class BasePlayerGroup {
         this.type = type;
     }
 
-    getAlivePlayers() {
-        return this.players.filter((p) => !p.dead && !p.disconnected);
-    }
-
-    getAliveTeammates(player: Player) {
-        return this.players.filter((p) => p != player && !p.dead && !p.disconnected);
-    }
-
     checkPlayers(): void {
         this.livingPlayers = this.players.filter((p) => !p.dead);
         this.allDeadOrDisconnected = this.players.every((p) => p.dead || p.disconnected);
@@ -65,8 +57,8 @@ class BasePlayerGroup {
      * kills all teammates, only called after last player on team thats not knocked gets knocked
      */
     killAllTeammates() {
-        const alivePlayers = this.getAlivePlayers();
-        for (const p of alivePlayers) {
+        for (const p of this.players) {
+            if (p.dead) continue;
             p.kill({
                 damageType: GameConfig.DamageType.Bleeding,
                 dir: p.dir,
@@ -94,40 +86,13 @@ class BasePlayerGroup {
      * @returns true if any players in the group have the self revive perk
      */
     checkSelfRevive() {
-        const alivePlayers = this.getAlivePlayers();
-        for (const p of alivePlayers) {
+        for (const p of this.livingPlayers) {
+            if (p.disconnected) continue;
             if (p.hasPerk("self_revive")) {
                 return true;
             }
         }
         return false;
-    }
-
-    /**
-     * @param player optional player to exclude
-     * @returns random alive player
-     */
-    randomPlayer(player?: Player) {
-        const alivePlayers = player
-            ? this.getAliveTeammates(player)
-            : this.getAlivePlayers();
-        return alivePlayers[util.randomInt(0, alivePlayers.length - 1)];
-    }
-
-    /** gets next alive player in the array, loops around if end is reached */
-    nextPlayer(currentPlayer: Player) {
-        const alivePlayers = this.getAlivePlayers();
-        const currentPlayerIndex = alivePlayers.indexOf(currentPlayer);
-        const newIndex = (currentPlayerIndex + 1) % alivePlayers.length;
-        return alivePlayers[newIndex];
-    }
-
-    /** gets previous alive player in the array, loops around if beginning is reached */
-    prevPlayer(currentPlayer: Player) {
-        const alivePlayers = this.getAlivePlayers();
-        const currentPlayerIndex = alivePlayers.indexOf(currentPlayer);
-        const newIndex = currentPlayerIndex == 0 ? alivePlayers.length - 1 : currentPlayerIndex - 1;
-        return alivePlayers[newIndex];
     }
 }
 

--- a/server/src/game/map.ts
+++ b/server/src/game/map.ts
@@ -420,8 +420,8 @@ export class GameMap {
 
         this.init(seed);
 
-        for (const player of this.game.playerBarn.players) {
-            player.sendData(this.mapStream.getBuffer());
+        for (const client of this.game.clientBarn.clients) {
+            client.sendData(this.mapStream.getBuffer());
         }
     }
 

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -270,10 +270,11 @@ export class PlayerBarn {
             params.pos ?? v2.create(this.game.map.width / 2, this.game.map.height / 2),
             0,
             client,
-            params.name ?? `TEST-${this.testPlayerCount++}`,
+            params.name ?? `TEST-${String.fromCharCode(65 + this.testPlayerCount++)}`,
             false,
             false,
         );
+        client.player = player;
 
         this.activatePlayer(player, group, team);
 

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -1,5 +1,5 @@
 import { type GameObjectDef, type LootDef, WeaponTypeToDefs } from "../../../../shared/defs/gameObjectDefs.ts";
-import { type EmoteDef, EmotesDefs } from "../../../../shared/defs/gameObjects/emoteDefs.ts";
+import { EmotesDefs } from "../../../../shared/defs/gameObjects/emoteDefs.ts";
 import {
     type BackpackDef,
     type BoostDef,
@@ -14,7 +14,6 @@ import type { MeleeDef } from "../../../../shared/defs/gameObjects/meleeDefs.ts"
 import { PerkProperties } from "../../../../shared/defs/gameObjects/perkDefs.ts";
 import type { ThrowableDef } from "../../../../shared/defs/gameObjects/throwableDefs.ts";
 import { UnlockDefs } from "../../../../shared/defs/gameObjects/unlockDefs.ts";
-
 import { GameObjectDefs, MapObjectDefs } from "../../../../shared/defs/register.ts";
 import {
     type Action,
@@ -27,7 +26,6 @@ import {
 } from "../../../../shared/gameConfig.ts";
 import * as net from "../../../../shared/net/net.ts";
 import { ObjectType } from "../../../../shared/net/objectSerializeFns.ts";
-import type { GroupStatus } from "../../../../shared/net/updateMsg.ts";
 import { type Circle, coldet } from "../../../../shared/utils/coldet.ts";
 import { collider } from "../../../../shared/utils/collider.ts";
 import { math } from "../../../../shared/utils/math.ts";
@@ -36,11 +34,12 @@ import { v2, type Vec2 } from "../../../../shared/utils/v2.ts";
 import { Config } from "../../config.ts";
 import { validateUserName } from "../../utils/badWords.ts";
 import { IDAllocator } from "../../utils/IDAllocator.ts";
+import { Client } from "../client.ts";
 import type { Game, JoinTokenData } from "../game.ts";
 import { Group, Team } from "../group.ts";
 import { InventoryManager } from "../inventoryManager.ts";
 import { QuestManager } from "../questManager.ts";
-import { type ClientSocket, NoOpSocket } from "../socket.ts";
+import { NoOpSocket } from "../socket.ts";
 import { WeaponManager } from "../weaponManager.ts";
 import type { Building } from "./building.ts";
 import { BaseGameObject, type DamageParams, type GameObject } from "./gameObject.ts";
@@ -141,33 +140,12 @@ export class PlayerBarn {
         return livingPlayers[util.randomInt(0, livingPlayers.length - 1)];
     }
 
-    addPlayer(socket: ClientSocket<Player | undefined>, joinMsg: net.JoinMsg) {
-        const joinData = this.game.joinTokens.get(joinMsg.matchPriv);
-
-        if (!joinData || joinData.expiresAt < Date.now()) {
-            this.game.logger.warn("player tried to join without or with expired join token");
-            socket.close();
-            if (joinData) {
-                this.game.joinTokens.delete(joinMsg.matchPriv);
-            }
-            return;
-        }
-        this.game.joinTokens.delete(joinMsg.matchPriv);
-
-        if (Config.rateLimitsEnabled) {
-            const count = this.livingPlayers.filter(
-                (p) =>
-                    p.ip === socket.ip()
-                    || p.findGameIp == joinData.findGameIp
-                    || (joinData.userId !== null && p.userId === joinData.userId),
-            );
-            if (count.length >= 5) {
-                socket.closeWithReason("rate_limited");
-                return;
-            }
-        }
-
-        const result = this.getGroupAndTeam(joinData);
+    addPlayer(
+        client: Client,
+        joinMsg: net.JoinMsg,
+        joinData: JoinTokenData,
+    ) {
+        const result = this.getGroupAndTeam(joinData.groupData);
         const group = result?.group;
         // solo 50v50 just chooses the smallest team everytime no matter what
         const team = this.game.map.factionMode && !this.game.isTeamMode
@@ -195,7 +173,7 @@ export class PlayerBarn {
         if (Config.uniqueInGameNames) {
             let count = 0;
             const loggedOutPlayers = this.game.playerBarn.players.filter(
-                (p) => !p.userId,
+                (p) => !p.client.userId,
             );
             while (loggedOutPlayers.find((p) => p.name === finalName)) {
                 const postFix = `-${++count}`;
@@ -211,11 +189,10 @@ export class PlayerBarn {
             this.game,
             pos,
             layer,
+            client,
             finalName,
-            socket as ClientSocket<Player>,
-            joinMsg,
-            joinData.findGameIp,
-            joinData.userId,
+            joinMsg.isMobile,
+            joinMsg.bot,
             joinData.quests,
         );
 
@@ -259,9 +236,8 @@ export class PlayerBarn {
         this.game.objectRegister.register(player);
         this.players.push(player);
         this.livingPlayers.push(player);
-        if (!this.game.modeManager.isSolo) {
-            this.livingPlayers.sort((a, b) => a.teamId - b.teamId);
-        }
+        this.livingPlayers.sort((a, b) => a.teamId - b.teamId);
+
         this.aliveCountDirty = true;
 
         this.game.updateData();
@@ -273,6 +249,7 @@ export class PlayerBarn {
         team?: Team;
         pos?: Vec2;
         name?: string;
+        userId?: string;
     }): Player {
         let group = params.group;
         let team = params.team;
@@ -285,17 +262,17 @@ export class PlayerBarn {
             team = this.getSmallestTeam();
         }
 
-        const socket = new NoOpSocket<Player>();
+        const client = new Client(this.game, new NoOpSocket(), params.userId || null, "");
+        this.game.clientBarn.clients.push(client);
 
         const player = new Player(
             this.game,
             params.pos ?? v2.create(this.game.map.width / 2, this.game.map.height / 2),
             0,
+            client,
             params.name ?? `TEST-${this.testPlayerCount++}`,
-            socket,
-            new net.JoinMsg(),
-            "",
-            null,
+            false,
+            false,
         );
 
         this.activatePlayer(player, group, team);
@@ -416,18 +393,14 @@ export class PlayerBarn {
             this.livingPlayers.sort((a, b) => a.teamId - b.teamId);
         }
 
+        for (const spectator of player.spectators) {
+            spectator.spectating = spectator.getNewPlayerToSpectate();
+        }
+
         player.obstacleOutfit?.destroy();
 
         this.game.checkGameOver();
         this.game.updateData();
-    }
-
-    sendMsgs() {
-        for (let i = 0; i < this.players.length; i++) {
-            const player = this.players[i];
-            if (player.disconnected) continue;
-            player.sendMsgs();
-        }
     }
 
     flush() {
@@ -451,7 +424,6 @@ export class PlayerBarn {
             player.inventoryDirty = false;
             player.weapsDirty = false;
             player.spectatorCountDirty = false;
-            player.activeIdDirty = false;
             player.groupStatusDirty = false;
             if (flushPlayerStatus) {
                 player.playerStatusDirty = false;
@@ -521,7 +493,7 @@ export class PlayerBarn {
         return team;
     }
 
-    getGroupAndTeam({ groupData }: JoinTokenData):
+    getGroupAndTeam(groupData: JoinTokenData["groupData"]):
         | {
             group?: Group;
             team?: Team;
@@ -661,7 +633,6 @@ export class Player extends BaseGameObject {
     inventoryDirty = true;
     weapsDirty = true;
     spectatorCountDirty = false;
-    activeIdDirty = true;
     hasFiredFlare = false;
     flareTimer = 0;
 
@@ -739,10 +710,7 @@ export class Player extends BaseGameObject {
     indoors = false;
     insideZoomRegion = false;
 
-    private _zoom: number = 0;
-    // zoom used for the area in which the server will send objects to the client
-    private _cullingZoom: number = 0;
-    private _cullingZoomTicker = 0;
+    _zoom: number = 0;
 
     get zoom(): number {
         return this._zoom;
@@ -751,15 +719,6 @@ export class Player extends BaseGameObject {
     set zoom(zoom: number) {
         if (zoom === this._zoom) return;
         assert(zoom !== 0);
-        // when changing to a lower zoom level
-        // we want to delay changing the culling zoom
-        // so objects only disappear from the client after the scope animation
-        // has finished, instead of flashing out of existence
-        if (zoom < this._cullingZoom) {
-            this._cullingZoomTicker = 0.5;
-        } else {
-            this._cullingZoom = zoom;
-        }
         this._zoom = zoom;
         this.zoomDirty = true;
     }
@@ -783,76 +742,21 @@ export class Player extends BaseGameObject {
         return this.weaponManager.activeWeapon;
     }
 
-    private _disconnected = false;
-
-    get disconnected(): boolean {
-        return this._disconnected;
-    }
-
-    set disconnected(disconnected: boolean) {
-        if (this.disconnected === disconnected) return;
-
-        this._disconnected = disconnected;
-        this.setGroupStatuses();
-    }
-
-    disconnect(reason?: string) {
-        this.disconnected = true;
-        if (reason) {
-            this.socket.closeWithReason(reason);
-        } else {
-            this.socket.close();
-        }
-    }
-
     private _spectatorCount = 0;
-    set spectatorCount(spectatorCount: number) {
-        if (this._spectatorCount === spectatorCount) return;
-        this._spectatorCount = spectatorCount;
-        this._spectatorCount = math.clamp(this._spectatorCount, 0, 255); // byte size limit
-        this.spectatorCountDirty = true;
+
+    recalculateSpectatorCount() {
+        const newCount = [...this.spectators].filter(c => !c.specAnon).length;
+        if (this._spectatorCount !== newCount) {
+            this._spectatorCount = newCount;
+            this.spectatorCountDirty = true;
+        }
     }
 
     get spectatorCount(): number {
         return this._spectatorCount;
     }
 
-    /** true when player starts spectating new player, only stays true for that given tick */
-    startedSpectating: boolean = false;
-
-    private _spectating?: Player;
-
-    get spectating(): Player | undefined {
-        return this._spectating;
-    }
-
-    set spectating(player: Player | undefined) {
-        if (player === this) {
-            throw new Error(
-                `Player ${player.name} tried spectate themselves (how tf did this happen?)`,
-            );
-        }
-        if (this._spectating === player) return;
-
-        if (this._spectating) {
-            this._spectating.spectatorCount--;
-            this._spectating.spectators.delete(this);
-        }
-        if (player) {
-            player.spectatorCount++;
-            player.spectators.add(this);
-        }
-
-        this._spectating = player;
-        this.startedSpectating = true;
-    }
-
-    spectateCooldown = 0;
-    spectateCooldownCount = 0;
-    spectateMsgCount = 0;
-    spectateMsgTicker = 0;
-
-    spectators = new Set<Player>();
+    spectators = new Set<Client>();
 
     outfit = "outfitBase";
 
@@ -1010,7 +914,7 @@ export class Player extends BaseGameObject {
         msg.role = role;
         msg.assigned = true;
         msg.playerId = this.__id;
-        this.game.broadcastMsg(net.MsgType.RoleAnnouncement, msg);
+        this.game.clientBarn.broadcastMsg(net.MsgType.RoleAnnouncement, msg);
 
         switch (role) {
             case "leader":
@@ -1228,7 +1132,7 @@ export class Player extends BaseGameObject {
             msg.role = "kill_leader";
             msg.assigned = true;
             msg.playerId = this.__id;
-            this.game.broadcastMsg(net.MsgType.RoleAnnouncement, msg);
+            this.game.clientBarn.broadcastMsg(net.MsgType.RoleAnnouncement, msg);
         }
     }
 
@@ -1373,9 +1277,14 @@ export class Player extends BaseGameObject {
         return surface;
     }
 
-    socket: ClientSocket<Player>;
+    client: Client;
 
-    ack = 0;
+    get userId() {
+        return this.client.userId;
+    }
+    get disconnected() {
+        return this.client.disconnected;
+    }
 
     name: string;
     isMobile: boolean;
@@ -1431,8 +1340,6 @@ export class Player extends BaseGameObject {
     kills = 0;
     timeAlive = 0;
 
-    msgsToSend: Array<{ type: number; msg: net.Msg }> = [];
-
     weaponManager = new WeaponManager(this);
     recoilTicker = 0;
 
@@ -1448,35 +1355,23 @@ export class Player extends BaseGameObject {
      */
     matchDataId: number;
 
-    userId: string | null = null;
-    ip: string;
-    // see comment on server/src/api/schema.ts
-    // about logging find_game IP's
-    findGameIp: string;
-
     constructor(
         game: Game,
         pos: Vec2,
         layer: number,
+        client: Client,
         name: string,
-        socket: ClientSocket<Player>,
-        joinMsg: net.JoinMsg,
-        findGameIp: string,
-        userId: string | null,
+        isBot: boolean,
+        isMobile: boolean,
         questIds?: string[],
     ) {
         super(game, pos);
 
-        this.matchDataId = game.playerBarn.nextMatchDataId++;
-
         this.layer = layer;
-
         this.name = name;
-        this.socket = socket;
-        socket.setUserData(this);
-        this.ip = socket.ip();
-        this.findGameIp = findGameIp;
-        this.userId = userId;
+        this.client = client;
+        this.isMobile = isMobile;
+        this.bot = Config.debug.allowBots && isBot;
 
         this.questManager.quests = (questIds ?? []).map((id) => ({
             id,
@@ -1484,11 +1379,9 @@ export class Player extends BaseGameObject {
             totalDelta: 0,
         }));
 
-        this.isMobile = joinMsg.isMobile;
+        this.matchDataId = game.playerBarn.nextMatchDataId++;
 
         this.weapons = this.weaponManager.weapons;
-
-        this.bot = Config.debug.allowBots && joinMsg.bot;
 
         let defaultItems = GameConfig.player.defaultItems;
 
@@ -1549,22 +1442,10 @@ export class Player extends BaseGameObject {
 
         this.weaponManager.showNextThrowable();
         this.recalculateScale();
-
-        this._cullingZoom = this.zoom;
     }
 
     update(dt: number): void {
         if (this.dead) {
-            this.spectateCooldown -= dt;
-
-            if (this.spectateMsgCount > 0) {
-                this.spectateMsgTicker += dt;
-                if (this.spectateMsgTicker > 3) {
-                    this.spectateMsgCount--;
-                    this.spectateMsgTicker = 0;
-                }
-            }
-
             if (!this.sentDeathEmote) {
                 this.sendDeathEmoteTicker -= dt;
                 if (this.sendDeathEmoteTicker <= 0) {
@@ -1964,7 +1845,7 @@ export class Player extends BaseGameObject {
                         this.weaponManager.showNextThrowable();
                     }
 
-                    this.msgsToSend.push({ type: net.MsgType.Pickup, msg });
+                    this.client.sendMsg(net.MsgType.Pickup, msg);
                 }
             }
 
@@ -2354,19 +2235,6 @@ export class Player extends BaseGameObject {
             this.zoom = finalZoom;
         }
 
-        if (this._cullingZoom !== this.zoom) {
-            this._cullingZoomTicker -= dt;
-            if (this._cullingZoomTicker <= 0) {
-                this._cullingZoom = this.zoom;
-            }
-        }
-        if (this.portrait !== this._cullingPortrait) {
-            this._cullingPortraitTicker -= dt;
-            if (this._cullingPortraitTicker <= 0) {
-                this._cullingPortrait = this.portrait;
-            }
-        }
-
         if (insideNoZoomRegion) {
             this.insideZoomRegion = false;
         }
@@ -2501,366 +2369,6 @@ export class Player extends BaseGameObject {
                 this.debug.moveObjMode.originalPos = undefined;
             }
         }
-    }
-
-    private _firstUpdate = true;
-    visibleObjects = new Set<GameObject>();
-    visibleMapIndicators = new Set<MapIndicator>();
-
-    msgStream = new net.MsgStream(new ArrayBuffer(65536));
-    sendMsgs(): void {
-        const msgStream = this.msgStream;
-        const game = this.game;
-        const playerBarn = game.playerBarn;
-        msgStream.stream.index = 0;
-
-        if (this._firstUpdate) {
-            const joinedMsg = new net.JoinedMsg();
-            joinedMsg.teamMode = this.game.teamMode;
-            joinedMsg.playerId = this.__id;
-            joinedMsg.started = game.started;
-            joinedMsg.teamMode = game.teamMode;
-            joinedMsg.emotes = this.loadout.emotes;
-            this.sendMsg(net.MsgType.Joined, joinedMsg);
-
-            const mapStream = game.map.mapStream.stream;
-
-            msgStream.stream.writeBytes(mapStream, 0, mapStream.byteIndex);
-        }
-
-        if (playerBarn.aliveCountDirty || this._firstUpdate) {
-            const aliveMsg = new net.AliveCountsMsg();
-            this.game.modeManager.updateAliveCounts(aliveMsg.teamAliveCounts);
-            msgStream.serializeMsg(net.MsgType.AliveCounts, aliveMsg);
-        }
-
-        const updateMsg = new net.UpdateMsg();
-
-        updateMsg.ack = this.ack;
-
-        if (game.gas.dirty || this._firstUpdate) {
-            updateMsg.gasDirty = true;
-            updateMsg.gasData = game.gas;
-        }
-
-        if (game.gas.timeDirty || this._firstUpdate) {
-            updateMsg.gasTDirty = true;
-            updateMsg.gasT = game.gas.gasT;
-        }
-
-        let player: Player;
-        if (this.spectating == undefined) {
-            // not spectating anyone
-            player = this;
-        } else if (this.spectating.dead) {
-            // was spectating someone but they died so find new player to spectate
-            player = this.spectating.killedBy && !this.spectating.killedBy.dead
-                ? this.spectating.killedBy
-                : playerBarn.randomPlayer();
-            if (player === this) {
-                player = playerBarn.randomPlayer();
-            }
-            this.spectating = player;
-        } else {
-            // spectating someone currently who is still alive
-            player = this.spectating;
-        }
-        // temporary guard while the spectating code is not fixed
-        if (!player) {
-            player = this;
-        }
-
-        const radius = player._cullingZoom + 4;
-        let width = player._cullingZoom + 4;
-        // client zoom tries to keep a 16/9 aspect ratio, mirror it here
-        let height = width / (16 / 9);
-        if (this._cullingPortrait) {
-            let tmp = width;
-            width = height;
-            height = tmp;
-        }
-        const rect = collider.createAabbExtents(player.pos, v2.create(width, height));
-
-        const newVisibleObjects = game.grid.intersectColliderSet(rect);
-        // client crashes if active player is not visible
-        // so make sure its always added to visible objects
-        newVisibleObjects.add(this);
-        newVisibleObjects.add(player);
-
-        for (const obj of this.visibleObjects) {
-            if (!newVisibleObjects.has(obj)) {
-                updateMsg.delObjIds.push(obj.__id);
-            }
-        }
-
-        for (const obj of newVisibleObjects) {
-            if (
-                !this.visibleObjects.has(obj)
-                || game.objectRegister.dirtyFull[obj.__id]
-            ) {
-                updateMsg.fullObjects.push(obj);
-            } else if (game.objectRegister.dirtyPart[obj.__id]) {
-                updateMsg.partObjects.push(obj);
-            }
-        }
-
-        this.visibleObjects = newVisibleObjects;
-
-        updateMsg.activePlayerId = player.__id;
-        if (this.startedSpectating) {
-            updateMsg.activePlayerIdDirty = true;
-
-            // build the active player data object manually
-            // To avoid setting the spectating player fields to dirty
-            updateMsg.activePlayerData = {
-                healthDirty: true,
-                health: player.health,
-                boostDirty: true,
-                boost: player.boost,
-                zoomDirty: true,
-                zoom: player.zoom,
-                actionDirty: true,
-                action: player.action,
-                inventoryDirty: true,
-                inventory: player.inventory,
-                scope: player.scope,
-                weapsDirty: true,
-                curWeapIdx: player.curWeapIdx,
-                weapons: player.weapons,
-                spectatorCountDirty: true,
-                spectatorCount: player.spectatorCount,
-            };
-            this.startedSpectating = false;
-        } else {
-            updateMsg.activePlayerIdDirty = player.activeIdDirty;
-            updateMsg.activePlayerData = player;
-        }
-
-        updateMsg.playerInfos = player._firstUpdate
-            ? playerBarn.players
-            : playerBarn.newPlayers;
-
-        updateMsg.deletedPlayerIds = playerBarn.deletedPlayers;
-
-        if (playerBarn.playerStatusTicker > playerBarn.playerStatusRate) {
-            let statuses = player.getPlayerStatus();
-            updateMsg.playerStatus = statuses;
-            updateMsg.playerStatusDirty = true;
-        }
-
-        if (player.groupStatusDirty) {
-            const teamPlayers = player.group!.players;
-
-            let statuses: GroupStatus[] = [];
-            for (const p of teamPlayers) {
-                statuses.push({
-                    health: p.health,
-                    disconnected: p.disconnected,
-                });
-            }
-            updateMsg.groupStatus = statuses;
-            updateMsg.groupStatusDirty = true;
-        }
-
-        const shouldSendEmote = (emote: Emote) => {
-            const emotePlayer = game.objectRegister.getById(emote.playerId) as
-                | Player
-                | undefined;
-
-            const emoteDef = GameObjectDefs.typeToDef(emote.type);
-
-            if (emotePlayer) {
-                if (!emote.isPing && !player.visibleObjects.has(emotePlayer)) {
-                    return false;
-                }
-
-                // regular emotes: always send if visible
-                if (!emote.isPing && !(emoteDef as EmoteDef).teamOnly) {
-                    return true;
-                }
-
-                // part of the same group
-                if (emotePlayer?.groupId === player.groupId) {
-                    return true;
-                }
-
-                // part of the same team
-                if (emotePlayer?.teamId === player.teamId && !emote.isPing) {
-                    return true;
-                }
-
-                // faction team leader
-                if (
-                    (emotePlayer.role === "leader"
-                        || emotePlayer.role === "captain"
-                        || emotePlayer.role === "last_man")
-                    && emotePlayer.teamId === player.teamId
-                ) {
-                    return true;
-                }
-            }
-
-            // always send map events pings
-            if (emote.isPing && emoteDef.type === "ping" && emoteDef.mapEvent) {
-                return true;
-            }
-
-            return false;
-        };
-
-        for (let i = 0; i < playerBarn.emotes.length; i++) {
-            const emote = playerBarn.emotes[i];
-            if (shouldSendEmote(emote)) {
-                updateMsg.emotes.push(emote);
-            }
-        }
-
-        const extendedRadius = 1.1 * radius;
-        const radiusSquared = extendedRadius * extendedRadius;
-
-        const bullets = game.bulletBarn.newBullets;
-        for (let i = 0; i < bullets.length; i++) {
-            const bullet = bullets[i];
-            if (
-                v2.lengthSqr(v2.sub(bullet.pos, player.pos)) < radiusSquared
-                || v2.lengthSqr(v2.sub(bullet.clientEndPos, player.pos)) < radiusSquared
-                || coldet.intersectSegmentCircle(
-                    bullet.pos,
-                    bullet.clientEndPos,
-                    player.pos,
-                    extendedRadius,
-                )
-            ) {
-                updateMsg.bullets.push(bullet);
-            }
-        }
-
-        for (let i = 0; i < game.explosionBarn.newExplosions.length; i++) {
-            const explosion = game.explosionBarn.newExplosions[i];
-            const rad = explosion.rad + extendedRadius;
-            if (v2.lengthSqr(v2.sub(explosion.pos, player.pos)) < rad * rad) {
-                updateMsg.explosions.push(explosion);
-            }
-        }
-
-        const planes = this.game.planeBarn.planes;
-        for (let i = 0; i < planes.length; i++) {
-            const plane = planes[i];
-            if (
-                coldet.testCircleAabb(plane.pos, plane.rad, rect.min, rect.max)
-                && coldet.testPointAabb(
-                    plane.pos,
-                    this.game.planeBarn.planeBounds.min,
-                    this.game.planeBarn.planeBounds.max,
-                )
-            ) {
-                updateMsg.planes.push(plane);
-            }
-        }
-        const newAirstrikeZones = this.game.planeBarn.newAirstrikeZones;
-        for (let i = 0; i < newAirstrikeZones.length; i++) {
-            const zone = newAirstrikeZones[i];
-            updateMsg.airstrikeZones.push(zone);
-        }
-
-        const indicators = this.game.mapIndicatorBarn.mapIndicators;
-        for (let i = 0; i < indicators.length; i++) {
-            const indicator = indicators[i];
-            if (indicator.dirty || !this.visibleMapIndicators.has(indicator)) {
-                updateMsg.mapIndicators.push(indicator);
-                this.visibleMapIndicators.add(indicator);
-            }
-            if (indicator.dead) {
-                this.visibleMapIndicators.delete(indicator);
-            }
-        }
-
-        if (playerBarn.killLeaderDirty || this._firstUpdate) {
-            updateMsg.killLeaderDirty = true;
-            updateMsg.killLeaderId = playerBarn.killLeader?.__id ?? 0;
-            updateMsg.killLeaderKills = playerBarn.killLeader?.kills ?? 0;
-        }
-
-        msgStream.serializeMsg(net.MsgType.Update, updateMsg);
-
-        for (let i = 0; i < this.msgsToSend.length; i++) {
-            const msg = this.msgsToSend[i];
-            msgStream.serializeMsg(msg.type, msg.msg);
-        }
-
-        this.msgsToSend.length = 0;
-
-        const globalMsgStream = this.game.msgsToSend.stream;
-        msgStream.stream.writeBytes(globalMsgStream, 0, globalMsgStream.byteIndex);
-
-        this.sendData(msgStream.getBuffer());
-        this._firstUpdate = false;
-    }
-
-    spectate(spectateMsg: net.SpectateMsg): void {
-        if (!this.dead) return;
-
-        if (this.spectateCooldown >= 0.75) {
-            this.spectateCooldownCount++;
-
-            if (this.spectateCooldownCount > 10) {
-                this.disconnect();
-                this.game.logger.error(
-                    `Game ${this.game.id} - Player ${this.name} disconnected for spamming SpectateMsg (cooldown)`,
-                );
-            }
-            return;
-        }
-        this.spectateCooldown = 1;
-
-        this.spectateMsgCount++;
-
-        if (this.spectateMsgCount > 50) {
-            this.disconnect();
-            this.game.logger.error(
-                `Game ${this.game.id} - Player ${this.name} Player ${this.name} disconnected for spamming SpectateMsg (count)`,
-            );
-            return;
-        }
-
-        // livingPlayers is used here instead of a more "efficient" option because its sorted while other options are not
-        const spectatablePlayers = this.game.playerBarn.livingPlayers.filter(
-            (p) =>
-                this != p
-                && !p.disconnected
-                && (this.game.modeManager.getPlayerAlivePlayersContext(this).length === 0
-                    || p.teamId == this.teamId),
-        );
-
-        let playerToSpec: Player | undefined;
-        switch (true) {
-            case spectateMsg.specBegin:
-                const groupExistsOrAlive = this.game.isTeamMode && this.group!.livingPlayers.length > 0;
-                const teamExistsOrAlive = this.game.map.factionMode && this.team!.livingPlayers.length > 0;
-                const aliveKiller = this.getAliveKiller();
-                const shouldSpecRandom = groupExistsOrAlive || teamExistsOrAlive || !aliveKiller;
-
-                if (!shouldSpecRandom) {
-                    playerToSpec = aliveKiller;
-                    break;
-                }
-
-                const players = this.game.map.factionMode && groupExistsOrAlive
-                    ? this.group!.livingPlayers
-                    : spectatablePlayers;
-
-                playerToSpec = util.randomItem(players);
-                break;
-            case spectateMsg.specNext:
-            case spectateMsg.specPrev:
-                const nextOrPrev = +spectateMsg.specNext - +spectateMsg.specPrev;
-                playerToSpec = util.wrappedArrayIndex(
-                    spectatablePlayers,
-                    spectatablePlayers.indexOf(this.spectating!) + nextOrPrev,
-                );
-                break;
-        }
-        this.spectating = playerToSpec;
     }
 
     /**
@@ -3010,7 +2518,7 @@ export class Player extends BaseGameObject {
         if (this.game.modeManager.showStatsMsg(this)) {
             const statsMsg = new net.PlayerStatsMsg();
             statsMsg.playerStats = this;
-            this.msgsToSend.push({ type: net.MsgType.PlayerStats, msg: statsMsg });
+            this.client.sendMsg(net.MsgType.PlayerStats, statsMsg);
         } else {
             const gameOverMsg = new net.GameOverMsg();
 
@@ -3020,13 +2528,10 @@ export class Player extends BaseGameObject {
             gameOverMsg.teamId = this.teamId;
             gameOverMsg.winningTeamId = winningTeamId;
             gameOverMsg.gameOver = !!winningTeamId;
-            this.msgsToSend.push({ type: net.MsgType.GameOver, msg: gameOverMsg });
+            this.client.sendMsg(net.MsgType.GameOver, gameOverMsg);
 
             for (const spectator of this.spectators) {
-                spectator.msgsToSend.push({
-                    type: net.MsgType.GameOver,
-                    msg: gameOverMsg,
-                });
+                spectator.sendMsg(net.MsgType.GameOver, gameOverMsg);
             }
         }
     }
@@ -3080,7 +2585,7 @@ export class Player extends BaseGameObject {
             downedMsg.killCreditId = params.source.__id;
         }
 
-        this.game.broadcastMsg(net.MsgType.Kill, downedMsg);
+        this.game.clientBarn.broadcastMsg(net.MsgType.Kill, downedMsg);
 
         // lone survivr can be given on knock or kill
         if (this.game.map.factionMode) {
@@ -3289,7 +2794,7 @@ export class Player extends BaseGameObject {
             this.lastDamagedBy.randomWeaponSwap(params);
         }
 
-        this.game.broadcastMsg(net.MsgType.Kill, killMsg);
+        this.game.clientBarn.broadcastMsg(net.MsgType.Kill, killMsg);
 
         if (this.role) {
             const roleMsg = new net.RoleAnnouncementMsg();
@@ -3298,7 +2803,7 @@ export class Player extends BaseGameObject {
             roleMsg.killed = true;
             roleMsg.playerId = this.__id;
             roleMsg.killerId = params.source?.__id ?? 0;
-            this.game.broadcastMsg(net.MsgType.RoleAnnouncement, roleMsg);
+            this.game.clientBarn.broadcastMsg(net.MsgType.RoleAnnouncement, roleMsg);
         }
 
         if (this.isKillLeader && this.role !== "the_hunted") {
@@ -3308,7 +2813,7 @@ export class Player extends BaseGameObject {
             roleMsg.killed = true;
             roleMsg.playerId = this.__id;
             roleMsg.killerId = params.source?.__id ?? 0;
-            this.game.broadcastMsg(net.MsgType.RoleAnnouncement, roleMsg);
+            this.game.clientBarn.broadcastMsg(net.MsgType.RoleAnnouncement, roleMsg);
         }
 
         if (this.game.map.mapDef.gameMode.killLeaderEnabled) {
@@ -3345,12 +2850,6 @@ export class Player extends BaseGameObject {
                 this.removeRole();
             }
         }
-
-        //
-        // Give spectators someone new to spectate
-        //
-
-        this.game.modeManager.assignNewSpectate(this);
 
         this.game.deadBodyBarn.addDeadBody(this.pos, this.__id, this.layer, params.dir);
 
@@ -3481,24 +2980,20 @@ export class Player extends BaseGameObject {
     }
 
     getAliveKiller(): Player | undefined {
-        let attempts = 0;
-        const findAliveKiller = (killer: Player | undefined): Player | undefined => {
-            attempts++;
-            if (attempts > 80) return undefined;
+        let aliveKiller: Player | undefined = this.killedBy;
+        const checkedPlayers = new Set<Player>();
 
-            if (!killer) return undefined;
-            if (!killer.dead) return killer;
-            if (
-                killer.killedBy
-                && killer.killedBy !== this
-                && killer.killedBy !== killer
-            ) {
-                return findAliveKiller(killer.killedBy);
-            }
+        for (let i = 0; i < 80; i++) {
+            if (!aliveKiller) return undefined;
+            if (aliveKiller === this) return undefined;
+            if (aliveKiller.killedBy === aliveKiller) return undefined;
+            if (checkedPlayers.has(aliveKiller)) return undefined;
 
-            return undefined;
-        };
-        return findAliveKiller(this.killedBy);
+            if (!aliveKiller.dead) return aliveKiller;
+            checkedPlayers.add(aliveKiller);
+
+            aliveKiller = aliveKiller.killedBy;
+        }
     }
 
     canDespawn() {
@@ -3722,8 +3217,7 @@ export class Player extends BaseGameObject {
     shootStart = false;
     shootHold = false;
     portrait = false;
-    private _cullingPortrait = false;
-    private _cullingPortraitTicker = 0;
+
     touchMoveActive = false;
     touchMoveDir = v2.create(1, 0);
     touchMoveLen = 255;
@@ -3744,8 +3238,6 @@ export class Player extends BaseGameObject {
     }
 
     handleInput(msg: net.InputMsg): void {
-        this.ack = msg.seq;
-
         if (this.dead) return;
         if (this.game.map.perkMode && !this.role) return;
 
@@ -3756,11 +3248,6 @@ export class Player extends BaseGameObject {
         this.moveUp = msg.moveUp;
         this.moveDown = msg.moveDown;
 
-        // same logic for `_cullingZoom`, see comment on `set zoom`
-        if (this.portrait != msg.portrait) {
-            this._cullingPortraitTicker = 0.5;
-        }
-        this.portrait = msg.portrait;
         this.touchMoveActive = msg.touchMoveActive;
         this.touchMoveDir = v2.normalizeSafe(msg.touchMoveDir);
         this.touchMoveLen = msg.touchMoveLen;
@@ -4395,10 +3882,7 @@ export class Player extends BaseGameObject {
         }
 
         obj.destroy();
-        this.msgsToSend.push({
-            type: net.MsgType.Pickup,
-            msg: pickupMsg,
-        });
+        this.client.sendMsg(net.MsgType.Pickup, pickupMsg);
     }
 
     // in original game, only called on snowball or potato collision
@@ -5171,15 +4655,5 @@ export class Player extends BaseGameObject {
         }
 
         this.speed = math.clamp(this.speed, 1, 10000);
-    }
-
-    sendMsg(type: net.MsgType, msg: net.AbstractMsg, bytes = 128): void {
-        const stream = new net.MsgStream(new ArrayBuffer(bytes));
-        stream.serializeMsg(type, msg);
-        this.sendData(stream.getBuffer());
-    }
-
-    sendData(buffer: Uint8Array<ArrayBuffer>): void {
-        this.socket.send(buffer);
     }
 }

--- a/server/src/game/questManager.ts
+++ b/server/src/game/questManager.ts
@@ -86,7 +86,7 @@ export class QuestManager {
         if (progress.length === 0) return;
 
         if (!this.player.disconnected) {
-            this.player.sendMsg(MsgType.UpdatePass, new UpdatePassMsg());
+            this.player.client.sendInstantMsg(MsgType.UpdatePass, new UpdatePassMsg());
         }
 
         this.game.sendQuestProgress(this.player.userId, progress);

--- a/server/src/game/weaponManager.ts
+++ b/server/src/game/weaponManager.ts
@@ -696,7 +696,7 @@ export class WeaponManager {
         if (itemDef.outsideOnly && this.player.indoors && !forceFire) {
             const msg = new net.PickupMsg();
             msg.type = net.PickupMsgType.GunCannotFire;
-            this.player.msgsToSend.push({ type: net.MsgType.Pickup, msg });
+            this.player.client.sendMsg(net.MsgType.Pickup, msg);
             return;
         }
 

--- a/shared/net/spectateMsg.ts
+++ b/shared/net/spectateMsg.ts
@@ -1,22 +1,20 @@
 import type { AbstractMsg, BitStream } from "./net.ts";
 
+export enum SpectateAction {
+    None,
+    Begin,
+    Next,
+    Prev,
+}
+
 export class SpectateMsg implements AbstractMsg {
-    specBegin = false;
-    specNext = false;
-    specPrev = false;
-    specForce = false;
+    action: SpectateAction = SpectateAction.None;
 
     serialize(s: BitStream) {
-        s.writeBoolean(this.specBegin);
-        s.writeBoolean(this.specNext);
-        s.writeBoolean(this.specPrev);
-        s.writeBoolean(this.specForce);
+        s.writeUint8(this.action);
     }
 
     deserialize(s: BitStream) {
-        this.specBegin = s.readBoolean();
-        this.specNext = s.readBoolean();
-        this.specPrev = s.readBoolean();
-        this.specForce = s.readBoolean();
+        this.action = s.readUint8();
     }
 }

--- a/tests/src/kill.test.ts
+++ b/tests/src/kill.test.ts
@@ -120,7 +120,7 @@ test("Downed by enemy, killed by teammate", () => {
     const playerB = game.playerBarn.addTestPlayer({ group });
     const playerC = game.playerBarn.addTestPlayer({ group });
 
-    playerB.disconnected = true;
+    playerB.client.disconnected = true;
 
     playerB.damage({
         amount: 999,
@@ -153,7 +153,7 @@ test("Downed by teammate, killed by teammate", () => {
     const playerA = game.playerBarn.addTestPlayer({ group });
     const playerB = game.playerBarn.addTestPlayer({ group });
 
-    playerB.disconnected = true;
+    playerB.client.disconnected = true;
 
     playerB.damage({
         amount: 999,
@@ -186,7 +186,7 @@ test("Downed by teammate, killed by enemy", () => {
     const playerB = game.playerBarn.addTestPlayer({ group });
     const playerC = game.playerBarn.addTestPlayer({ group });
 
-    playerB.disconnected = true;
+    playerB.client.disconnected = true;
 
     playerB.damage({
         amount: 999,
@@ -219,7 +219,7 @@ test("Downed by teammate, killed by bleeding", () => {
     const playerA = game.playerBarn.addTestPlayer({ group });
     const playerB = game.playerBarn.addTestPlayer({ group });
 
-    playerB.disconnected = true;
+    playerB.client.disconnected = true;
 
     playerB.damage({
         amount: 999,
@@ -250,7 +250,7 @@ test("Downed by teammate, killed by gas", () => {
     const playerA = game.playerBarn.addTestPlayer({ group });
     const playerB = game.playerBarn.addTestPlayer({ group });
 
-    playerB.disconnected = true;
+    playerB.client.disconnected = true;
 
     playerB.damage({
         amount: 999,

--- a/tests/src/quests.test.ts
+++ b/tests/src/quests.test.ts
@@ -7,8 +7,7 @@ test("Kill enemies inside building test", () => {
     const game = createGame(TeamMode.Solo, "test_normal");
     game.map.genBuilding("club_complex_01", game.map.center, 0, 0);
 
-    const playerA = game.playerBarn.addTestPlayer({});
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_club_kills",
@@ -55,8 +54,7 @@ test("Kill enemies inside building test", () => {
 test("Players shouldn't get placement progress for just disconnecting", () => {
     const game = createGame(TeamMode.Solo, "test_normal");
 
-    const playerA = game.playerBarn.addTestPlayer({});
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_top_solo",
@@ -67,7 +65,7 @@ test("Players shouldn't get placement progress for just disconnecting", () => {
 
     expect(playerA.questManager.quests[0].delta).toBe(0);
 
-    playerA.socket.close();
+    playerA.client.socket.close();
 
     // player leaving shouldn't count as progress
     expect(playerA.questManager.quests[0].totalDelta).toBe(0);
@@ -76,8 +74,7 @@ test("Players shouldn't get placement progress for just disconnecting", () => {
 test("Solo placement success on win", () => {
     const game = createGame(TeamMode.Solo, "test_normal");
 
-    const playerA = game.playerBarn.addTestPlayer({});
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_top_solo",
@@ -109,8 +106,7 @@ test("Solo placement success on win", () => {
 test("Solo placement success on death", () => {
     const game = createGame(TeamMode.Solo, "test_normal");
 
-    const playerA = game.playerBarn.addTestPlayer({});
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_top_solo",
@@ -141,8 +137,7 @@ test("Solo placement success on death", () => {
 test("Solo placement test fail on death", () => {
     const game = createGame(TeamMode.Solo, "test_normal");
 
-    const playerA = game.playerBarn.addTestPlayer({});
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_top_solo",
@@ -173,8 +168,7 @@ test("Squad placement success on win", () => {
     const game = createGame(TeamMode.Squad, "test_normal");
 
     const groupA = game.playerBarn.addGroup(false);
-    const playerA = game.playerBarn.addTestPlayer({ group: groupA });
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ group: groupA, userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_top_squad",
@@ -208,8 +202,7 @@ test("Squad placement success on death", () => {
     const game = createGame(TeamMode.Squad, "test_normal");
 
     const groupA = game.playerBarn.addGroup(false);
-    const playerA = game.playerBarn.addTestPlayer({ group: groupA });
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ group: groupA, userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_top_squad",
@@ -251,8 +244,7 @@ test("Squad placement fail on death", () => {
     const game = createGame(TeamMode.Squad, "test_normal");
 
     const groupA = game.playerBarn.addGroup(false);
-    const playerA = game.playerBarn.addTestPlayer({ group: groupA });
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ group: groupA, userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_top_squad",
@@ -292,8 +284,7 @@ test("Squad placement fail on death", () => {
 test("Survived time on death", () => {
     const game = createGame(TeamMode.Solo, "test_normal");
 
-    const playerA = game.playerBarn.addTestPlayer({});
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_survived",
@@ -317,8 +308,7 @@ test("Survived time on death", () => {
 test("Survived time on win", () => {
     const game = createGame(TeamMode.Solo, "test_normal");
 
-    const playerA = game.playerBarn.addTestPlayer({});
-    playerA.userId = "meow";
+    const playerA = game.playerBarn.addTestPlayer({ userId: "meow" });
     playerA.questManager.quests = [
         {
             id: "quest_survived",

--- a/tests/src/reviving.test.ts
+++ b/tests/src/reviving.test.ts
@@ -3,6 +3,7 @@ import { GameConfig, TeamMode } from "../../shared/gameConfig.ts";
 import { InputMsg } from "../../shared/net/inputMsg.ts";
 import { v2 } from "../../shared/utils/v2.ts";
 import { createGame } from "./gameTestHelpers.ts";
+import "./testHelpers.ts";
 
 // + 0.1 to account for off by one tick on the timer system lol
 const reviveDur = GameConfig.player.reviveDuration + 0.1;
@@ -51,7 +52,7 @@ test("Normal 2 players successful revive", () => {
     const msg = new InputMsg();
     msg.addInput(GameConfig.Input.Interact);
     playerA.handleInput(msg);
-    expect(playerA.playerBeingRevived).toBe(playerB);
+    expect(playerA.playerBeingRevived).toBeSamePlayer(playerB);
 
     game.step(reviveDur);
 
@@ -140,7 +141,7 @@ test("Normal medic reviving multiple players", () => {
     const msg = new InputMsg();
     msg.addInput(GameConfig.Input.Interact);
     medic.handleInput(msg);
-    expect(medic.playerBeingRevived).toBe(playerB);
+    expect(medic.playerBeingRevived).toBeSamePlayer(playerB);
 
     game.step(reviveDur);
 
@@ -172,7 +173,7 @@ test("Faction 2 players successful revive", () => {
     const msg = new InputMsg();
     msg.addInput(GameConfig.Input.Interact);
     playerA.handleInput(msg);
-    expect(playerA.playerBeingRevived).toBe(playerB);
+    expect(playerA.playerBeingRevived).toBeSamePlayer(playerB);
 
     game.step(reviveDur);
 
@@ -311,7 +312,7 @@ test("Faction medic reviving multiple players", () => {
     const msg = new InputMsg();
     msg.addInput(GameConfig.Input.Interact);
     medic.handleInput(msg);
-    expect(medic.playerBeingRevived).toBe(playerB);
+    expect(medic.playerBeingRevived).toBeSamePlayer(playerB);
 
     game.step(reviveDur);
 

--- a/tests/src/spectating.test.ts
+++ b/tests/src/spectating.test.ts
@@ -1,0 +1,231 @@
+import { expect, test } from "vitest";
+import { GameConfig, TeamMode } from "../../shared/gameConfig.ts";
+import { MsgType, SpectateMsg } from "../../shared/net/net.ts";
+import { SpectateAction } from "../../shared/net/spectateMsg.ts";
+import { v2 } from "../../shared/utils/v2.ts";
+import { createGame } from "./gameTestHelpers.ts";
+import "./testHelpers.ts";
+
+const specBegin = new SpectateMsg();
+specBegin.action = SpectateAction.Begin;
+
+const specNext = new SpectateMsg();
+specNext.action = SpectateAction.Next;
+
+const specPrev = new SpectateMsg();
+specPrev.action = SpectateAction.Prev;
+
+const spectateDeathCooldown = 2;
+const spectateTeammateCooldown = 0.1;
+const spectateSoloCooldown = 1;
+
+test("Spectate killer", () => {
+    const game = createGame(TeamMode.Solo, "test_normal");
+    game.preventStart = true;
+
+    const playerA = game.playerBarn.addTestPlayer({});
+    const playerB = game.playerBarn.addTestPlayer({});
+    const playerC = game.playerBarn.addTestPlayer({});
+    const playerD = game.playerBarn.addTestPlayer({});
+
+    playerA.damage({
+        damageType: GameConfig.DamageType.Player,
+        source: playerB,
+        amount: 999,
+        dir: v2.randomUnit(),
+    });
+    playerA.client.handleMsg(MsgType.Spectate, specBegin);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerB.damage({
+        damageType: GameConfig.DamageType.Player,
+        source: playerC,
+        amount: 999,
+        dir: v2.randomUnit(),
+    });
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    game.step(spectateDeathCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerC);
+
+    playerC.damage({
+        damageType: GameConfig.DamageType.Player,
+        source: playerC,
+        amount: 999,
+        dir: v2.randomUnit(),
+    });
+
+    game.step(spectateDeathCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerD);
+});
+
+test("Spectate solo", () => {
+    const game = createGame(TeamMode.Solo, "test_normal");
+    game.preventStart = true;
+
+    const playerA = game.playerBarn.addTestPlayer({});
+    const playerB = game.playerBarn.addTestPlayer({});
+    const playerC = game.playerBarn.addTestPlayer({});
+    const playerD = game.playerBarn.addTestPlayer({});
+
+    playerA.damage({
+        damageType: GameConfig.DamageType.Player,
+        source: playerB,
+        amount: 999,
+        dir: v2.randomUnit(),
+    });
+    playerA.client.handleMsg(MsgType.Spectate, specBegin);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(spectateSoloCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerC);
+
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(spectateSoloCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerD);
+
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(spectateSoloCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerA.client.handleMsg(MsgType.Spectate, specPrev);
+    game.step(spectateSoloCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerD);
+
+    // test the cooldown
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(0.4);
+    expect(playerA.client.spectating).toBeSamePlayer(playerD);
+    game.step(1);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    // test manually switching while killer is dead
+    playerB.damage({
+        damageType: GameConfig.DamageType.Player,
+        source: playerC,
+        amount: 999,
+        dir: v2.randomUnit(),
+    });
+    game.step(0.1);
+    // we stay spectating playerB until the 2 seconds timer is over or manually switching
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(0.4);
+    expect(playerA.client.spectating).toBeSamePlayer(playerC);
+
+    playerA.client.handleMsg(MsgType.Spectate, specPrev);
+    game.step(spectateSoloCooldown);
+    // we shouldn't be able to go back to the playerB since they are dead
+    expect(playerA.client.spectating).toBeSamePlayer(playerD);
+});
+
+test("Spectate teammates", () => {
+    const game = createGame(TeamMode.Squad, "test_normal");
+    game.preventStart = true;
+
+    const group = game.playerBarn.addGroup(false);
+
+    const playerA = game.playerBarn.addTestPlayer({ group });
+    const playerB = game.playerBarn.addTestPlayer({ group });
+    const playerC = game.playerBarn.addTestPlayer({ group });
+    const playerD = game.playerBarn.addTestPlayer({ group });
+
+    const playerE = game.playerBarn.addTestPlayer({});
+
+    playerA.kill({
+        damageType: GameConfig.DamageType.Player,
+        source: playerE,
+        amount: 999,
+        dir: v2.randomUnit(),
+    });
+
+    // test wrap around
+    playerA.client.handleMsg(MsgType.Spectate, specBegin);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(spectateTeammateCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerC);
+
+    playerA.client.handleMsg(MsgType.Spectate, specPrev);
+    game.step(spectateTeammateCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerA.client.handleMsg(MsgType.Spectate, specPrev);
+    game.step(spectateTeammateCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerD);
+
+    for (const player of [playerB, playerC, playerD]) {
+        // "are their heads all going to explode"
+        // - Noelle seeing me write this
+
+        player.kill({
+            damageType: GameConfig.DamageType.Player,
+            source: playerE,
+            amount: 999,
+            dir: v2.randomUnit(),
+        });
+    }
+    // now that all teammates are dead we should be able to spectate non teammates :)
+    game.step(spectateDeathCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerE);
+});
+
+test("Spectate faction teammtes", () => {
+    const game = createGame(TeamMode.Squad, "test_faction");
+    game.preventStart = true;
+
+    const teamA = game.playerBarn.addTeam(1);
+    const group = game.playerBarn.addGroup(false);
+
+    const playerA = game.playerBarn.addTestPlayer({ team: teamA, group });
+    const playerB = game.playerBarn.addTestPlayer({ team: teamA, group });
+    const playerC = game.playerBarn.addTestPlayer({ team: teamA, group });
+    const playerD = game.playerBarn.addTestPlayer({ team: teamA, group });
+    const playerE = game.playerBarn.addTestPlayer({ team: teamA, group });
+    const playerF = game.playerBarn.addTestPlayer({ team: teamA, group });
+
+    const teamB = game.playerBarn.addTeam(2);
+    game.playerBarn.addTestPlayer({ team: teamB });
+
+    playerA.kill({
+        damageType: GameConfig.DamageType.Player,
+        source: playerE,
+        amount: 999,
+        dir: v2.randomUnit(),
+    });
+
+    playerA.client.handleMsg(MsgType.Spectate, specBegin);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(spectateTeammateCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerC);
+
+    playerA.client.handleMsg(MsgType.Spectate, specPrev);
+    game.step(spectateTeammateCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    playerA.client.handleMsg(MsgType.Spectate, specPrev);
+    game.step(spectateTeammateCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerF);
+
+    playerA.client.handleMsg(MsgType.Spectate, specNext);
+    game.step(spectateTeammateCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerB);
+
+    for (const player of [playerB, playerC, playerD]) {
+        player.kill({
+            damageType: GameConfig.DamageType.Player,
+            source: playerE,
+            amount: 999,
+            dir: v2.randomUnit(),
+        });
+    }
+
+    // now that all group teammates are dead we should spectate another faction team member
+    game.step(spectateDeathCooldown);
+    expect(playerA.client.spectating).toBeSamePlayer(playerE);
+});

--- a/tests/src/testHelpers.ts
+++ b/tests/src/testHelpers.ts
@@ -2,6 +2,7 @@ import { expect } from "vitest";
 
 import type { GameObjectDef } from "../../shared/defs/gameObjectDefs.ts";
 
+import type { Player } from "../../server/src/game/objects/player.ts";
 import type { MapObjectDef } from "../../shared/defs/mapObjectsTyping.ts";
 import { Main } from "../../shared/defs/maps/baseDefs.ts";
 import { GameObjectDefs, MapObjectDefs } from "../../shared/defs/register.ts";
@@ -14,6 +15,8 @@ interface GameTestHelpers<R = unknown> {
     toBeValidGameObj: (type?: GameObjectDef["type"]) => R;
     toBeValidLoot: (type?: GameObjectDef["type"]) => R;
     toBeValidLootTier: () => R;
+
+    toBeSamePlayer: (obj?: Player) => R;
 }
 
 declare module "vitest" {
@@ -122,6 +125,23 @@ expect.extend({
         if (!(received in Main.lootTable)) {
             return {
                 message: () => `Expected '${received}' to be a valid loot table`,
+                pass: false,
+            };
+        }
+
+        return { pass: true, message: () => "" };
+    },
+
+    toBeSamePlayer: (received: Player | undefined, expected: Player) => {
+        if (!received) {
+            return {
+                message: () => `Expected a player instance, received '${expected}'`,
+                pass: false,
+            };
+        }
+        if (received.__id !== expected.__id) {
+            return {
+                message: () => `Expected player '${received.name}' to be '${expected.name}'`,
                 pass: false,
             };
         }


### PR DESCRIPTION
This separates the net code handling from the Player class to a Client class, making the giant mess of player.ts a bit less messy...

And will also allow joining a game directly as spectator in the future without hacks

...also refactors spectating because old code was garbage :)

WIP because need to do more cleanups

TODO:
- [x] Move zoom handling from player to client
- [x] Move portrait handling from player to client
- [x] See if there's stuff i forgot to remove from player.ts
- [x] Rework spectator cooldown
- [x] Go to sleep (its literally 04:20 help)
