### PR TITLE
fix: remove pod ownership upon death or disconnect

### DIFF
--- a/server/src/game/objects/loot.ts
+++ b/server/src/game/objects/loot.ts
@@ -340,8 +340,13 @@ export class Loot extends BaseGameObject {
 
     update(dt: number): void {
         if (this.hasOwner) {
+            const owner = this.game.objectRegister.getById(this.ownerId);
             this.removeOwnerTicker += dt;
-            if (this.removeOwnerTicker > 2) {
+            if (
+                this.removeOwnerTicker > 2 ||
+                !owner ||
+                (owner.__type === ObjectType.Player && (owner.dead || owner.disconnected))
+            ) {
                 this.ownerId = 0;
                 this.setDirty();
             }


### PR DESCRIPTION
https://discord.com/channels/1407084649343352852/1506763998270591107

If the pod owner dies before they can pick up the loot, the game still treats them as if they exist and will prevent other players from picking up the pod loot temporarily. This commit removes that post-mortem ownership.