### PR TITLE
fix: remove prefix matching for destruction quests

### DIFF
--- a/server/src/game/questManager.ts
+++ b/server/src/game/questManager.ts
@@ -214,7 +214,6 @@ export function questDelta<E extends keyof QuestEventPayloads>(
                 break;
             }
 
-            value = p.objectType.startsWith(obstacleType) ? 1 : 0;
             break;
         }
     }


### PR DESCRIPTION
https://discord.com/channels/1407084649343352852/1512753530174181489

There is no mapObject that uses the prefix matcher and doesn't already go through the objectDef.obstacleType checker. The prefix matcher is just a random liability and falsely classifies potatoes as `pot`.