### PR TITLE
Run each game process on its own port

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -21,6 +21,8 @@ export function getConfig(isProduction: boolean, dir: string) {
             port: 8001,
             apiServerUrl: "",
             thisRegion: "local",
+            firstGamePort: 9000,
+            maxGames: 64,
         },
         vite: {
             host: "127.0.0.1",

--- a/configType.ts
+++ b/configType.ts
@@ -52,6 +52,18 @@ export interface ConfigType {
          * Should be a valid key from the `regions` object.
          */
         thisRegion: string;
+
+        /**
+         * First port used by games, each game gets its own port.
+         *
+         * The last port will be `firstGamePort` + `maxGames`.
+         */
+        firstGamePort: number;
+
+        /**
+         * Maximum amount of games the server can run.
+         */
+        maxGames: number;
     };
 
     /**

--- a/server/src/game/gameProcess.ts
+++ b/server/src/game/gameProcess.ts
@@ -1,11 +1,15 @@
 import fs from "node:fs";
 import { platform } from "node:os";
 import path from "node:path";
+import { App, SSLApp, type WebSocket } from "uWebSockets.js";
+import type { GameWsDisconnectReason } from "../../../shared/types/api.ts";
 import { Logger } from "../../../shared/utils/logger.ts";
 import { Config } from "../config.ts";
-import { apiPrivateRouter } from "../utils/apiRouter.ts";
+import { apiPrivateRouter, checkIp } from "../utils/apiRouter.ts";
 import { logErrorToWebhook } from "../utils/logger.ts";
+import { HTTPRateLimit, WebSocketRateLimit } from "../utils/rateLimit.ts";
 import type { SaveGameBody } from "../utils/types.ts";
+import { uwsHelpers } from "../utils/uwsHelpers.ts";
 import type { Client } from "./client.ts";
 import { Game } from "./game.ts";
 import { type ProcessMsg, ProcessMsgType } from "./ipcTypes.ts";
@@ -15,15 +19,33 @@ function sendMsg(msg: ProcessMsg) {
     process.send!(msg);
 }
 
-process.on("disconnect", () => {
-    process.exit();
-});
-
 let game: ServerGame | undefined;
 let gameWeakRef: WeakRef<ServerGame> | undefined;
 const socketIdToSocket = new Map<string, ProcessSocket<Client>>();
 
 const procLogger = new Logger(Config.logging, `GameProc-${process.pid}`);
+
+function broadcastDisconnect(reason: GameWsDisconnectReason) {
+    if (game) {
+        for (const client of game.clientBarn.clients) {
+            client.socket.close(reason);
+        }
+    }
+}
+process.on("disconnect", () => {
+    broadcastDisconnect("server_restart");
+    process.exit();
+});
+
+process.on("uncaughtException", async (err) => {
+    console.error(err);
+    broadcastDisconnect("server_crashed");
+
+    game = undefined;
+    await logErrorToWebhook("server", "Game process error", err);
+
+    process.exit(1);
+});
 
 function stopGame() {
     socketIdToSocket.clear();
@@ -298,11 +320,182 @@ setGameInterval(() => {
     socketMsgs.length = 0;
 }, 1000 / Config.netSyncTps);
 
-process.on("uncaughtException", async (err) => {
-    console.error(err);
-    game = undefined;
+interface GameSocketData {
+    ip: string;
+    rateLimit: Record<symbol, number>;
+    disconnectReason?: GameWsDisconnectReason;
+    clientSocket: UwsSocket;
+}
 
-    await logErrorToWebhook("server", "Game process error", err);
+class UwsSocket extends ClientSocket<Client> {
+    private _socket: WebSocket<GameSocketData>;
+    private _ip: string;
 
-    process.exit(1);
+    _closed = false;
+    constructor(socket: WebSocket<GameSocketData>, ip: string) {
+        super();
+        this._socket = socket;
+        this._ip = ip;
+    }
+
+    ip(): string {
+        return this._ip;
+    }
+
+    closed(): boolean {
+        return this._closed;
+    }
+
+    send(data: Uint8Array<ArrayBuffer>): void {
+        if (this._closed) return;
+        this._socket.send(data, true, false);
+    }
+
+    close(reason?: GameWsDisconnectReason): void {
+        if (this._closed) return;
+        this._closed = true;
+        this._socket.end(reason ? 3000 : 0, reason);
+    }
+}
+
+const app = Config.gameServer.ssl
+    ? SSLApp({
+        key_file_name: Config.gameServer.ssl.keyFile,
+        cert_file_name: Config.gameServer.ssl.certFile,
+    })
+    : App();
+
+const gameHTTPRateLimit = new HTTPRateLimit(5, 1000);
+const gameWsRateLimit = new WebSocketRateLimit(500, 1000, 5);
+
+app.ws<GameSocketData>("/play", {
+    idleTimeout: 30,
+    maxPayloadLength: 1024,
+
+    async upgrade(res, req, context): Promise<void> {
+        res.onAborted((): void => {
+            res.aborted = true;
+        });
+        const wskey = req.getHeader("sec-websocket-key");
+        const wsProtocol = req.getHeader("sec-websocket-protocol");
+        const wsExtensions = req.getHeader("sec-websocket-extensions");
+
+        if (!game) {
+            procLogger.warn("Websocket upgrade closed: process not running a game");
+            res.end();
+            return;
+        }
+
+        const ip = uwsHelpers.getIp(res, req, Config.gameServer.proxyIPHeader);
+
+        if (!ip) {
+            game.logger.warn("Invalid IP Found");
+            res.end();
+            return;
+        }
+
+        if (gameHTTPRateLimit.isRateLimited(ip) || gameWsRateLimit.isIpRateLimited(ip)) {
+            res.cork(() => {
+                game!.logger.warn("Websocket upgrade closed: Rate limited");
+                res.writeStatus("429 Too Many Requests");
+                res.write("429 Too Many Requests");
+                res.end();
+            });
+            return;
+        }
+
+        const searchParams = new URLSearchParams(req.getQuery());
+        const gameId = searchParams.get("gameId");
+
+        if (!gameId) {
+            game.logger.warn("Websocket upgrade closed: no game ID");
+            uwsHelpers.forbidden(res);
+            return;
+        }
+
+        if (game.id !== gameId) {
+            game.logger.warn("Websocket upgrade closed: invalid game ID");
+            uwsHelpers.forbidden(res);
+            return;
+        }
+
+        if (!game.canJoin) {
+            game.logger.warn("Websocket upgrade closed: game already started");
+            uwsHelpers.forbidden(res);
+            return;
+        }
+
+        gameWsRateLimit.ipConnected(ip);
+
+        let disconnectReason: GameWsDisconnectReason | undefined = undefined;
+
+        const ipData = await checkIp(ip);
+
+        if (ipData?.banned) {
+            disconnectReason = "ip_banned";
+        } else if (ipData?.behindProxy) {
+            disconnectReason = "behind_proxy";
+        }
+
+        if (res.aborted) return;
+        res.cork(() => {
+            if (res.aborted) return;
+            res.upgrade<GameSocketData>(
+                {
+                    rateLimit: {},
+                    ip,
+                    disconnectReason,
+                    clientSocket: undefined as unknown as UwsSocket,
+                },
+                wskey,
+                wsProtocol,
+                wsExtensions,
+                context,
+            );
+        });
+    },
+
+    open(socket: WebSocket<GameSocketData>) {
+        const data = socket.getUserData();
+
+        if (data.disconnectReason) {
+            socket.end(3000, data.disconnectReason);
+            return;
+        }
+
+        data.clientSocket = new UwsSocket(socket, data.ip);
+    },
+
+    message(socket: WebSocket<GameSocketData>, message) {
+        const data = socket.getUserData();
+        if (!game) {
+            data.clientSocket.close();
+            return;
+        }
+        if (gameWsRateLimit.isRateLimited(socket.getUserData().rateLimit)) {
+            procLogger.warn("Game websocket rate limited, closing socket.");
+            socket.end(3000, "rate_limited");
+            return;
+        }
+        game.clientBarn.handleMsg(message, data.clientSocket);
+    },
+
+    close(socket: WebSocket<GameSocketData>) {
+        const data = socket.getUserData();
+        data.clientSocket._closed = true;
+        gameWsRateLimit.ipDisconnected(data.ip);
+        game?.clientBarn?.handleSocketClose(data.clientSocket);
+    },
+});
+
+const port = parseInt(process.argv[2]);
+
+app.listen(Config.gameServer.host, port, 1, (socket) => {
+    if (!socket) {
+        throw new Error(`Port ${port} is already in use`);
+    }
+
+    procLogger.info(
+        `Listening on ${Config.gameServer.host}:${port}`,
+    );
 });

--- a/server/src/game/gameProcess.ts
+++ b/server/src/game/gameProcess.ts
@@ -21,7 +21,6 @@ function sendMsg(msg: ProcessMsg) {
 
 let game: ServerGame | undefined;
 let gameWeakRef: WeakRef<ServerGame> | undefined;
-const socketIdToSocket = new Map<string, ProcessSocket<Client>>();
 
 const procLogger = new Logger(Config.logging, `GameProc-${process.pid}`);
 
@@ -48,7 +47,6 @@ process.on("uncaughtException", async (err) => {
 });
 
 function stopGame() {
-    socketIdToSocket.clear();
     game = undefined;
 
     // make sure game is properly free'd
@@ -197,55 +195,9 @@ class ServerGame extends Game {
     }
 }
 
-const socketMsgs: Array<{
-    socketId: string;
-    data: Uint8Array;
-    ip: string;
-}> = [];
-
-class ProcessSocket<T extends object> extends ClientSocket<T> {
-    private _id: string;
-    private _ip: string;
-    _closed = false;
-    constructor(id: string, ip: string) {
-        super();
-        this._id = id;
-        this._ip = ip;
-    }
-
-    ip(): string {
-        return this._ip;
-    }
-
-    closed(): boolean {
-        return this._closed;
-    }
-
-    send(data: Uint8Array<ArrayBuffer>): void {
-        if (this.closed()) return;
-
-        socketMsgs.push({
-            socketId: this._id,
-            data,
-            ip: "",
-        });
-    }
-    close(reason?: string): void {
-        this._closed = true;
-        sendMsg({
-            type: ProcessMsgType.SocketClose,
-            socketId: this._id,
-            reason,
-        });
-        socketIdToSocket.delete(this._id);
-    }
-}
-
 let lastMsgTime = Date.now();
 process.on("message", (msg: ProcessMsg) => {
-    if (msg.type) {
-        lastMsgTime = Date.now();
-    }
+    lastMsgTime = Date.now();
 
     if (msg.type === ProcessMsgType.Create && !game) {
         game = new ServerGame(msg.id, msg.config);
@@ -258,27 +210,6 @@ process.on("message", (msg: ProcessMsg) => {
         case ProcessMsgType.AddJoinToken:
             game.addJoinTokens(msg.tokens, msg.autoFill);
             break;
-        case ProcessMsgType.SocketOpen: {
-            const socket = new ProcessSocket<Client>(msg.socketId, msg.ip);
-            socketIdToSocket.set(msg.socketId, socket);
-            break;
-        }
-        case ProcessMsgType.ClientSocketMsg: {
-            const socket = socketIdToSocket.get(msg.socketId);
-            if (socket) {
-                game.clientBarn.handleMsg(msg.data as ArrayBuffer, socket);
-            }
-            break;
-        }
-        case ProcessMsgType.SocketClose: {
-            const socket = socketIdToSocket.get(msg.socketId);
-            if (socket) {
-                socket._closed = true;
-                game.clientBarn.handleSocketClose(socket);
-                socketIdToSocket.delete(msg.socketId);
-            }
-            break;
-        }
     }
 });
 
@@ -313,11 +244,6 @@ setGameInterval(() => {
 
 setGameInterval(() => {
     game?.netSync();
-    sendMsg({
-        type: ProcessMsgType.ServerSocketMsg,
-        msgs: socketMsgs,
-    });
-    socketMsgs.length = 0;
 }, 1000 / Config.netSyncTps);
 
 interface GameSocketData {

--- a/server/src/game/gameProcessManager.ts
+++ b/server/src/game/gameProcessManager.ts
@@ -5,6 +5,7 @@ import { type MapDefKey, MapDefs } from "../../../shared/defs/mapDefs.ts";
 import type { TeamMode } from "../../../shared/gameConfig.ts";
 import type { GameWsDisconnectReason } from "../../../shared/types/api.ts";
 import { util } from "../../../shared/utils/util.ts";
+import { Config } from "../config.ts";
 import { ServerLogger } from "../utils/logger.ts";
 import { type FindGamePrivateBody, type ServerGameConfig } from "../utils/types.ts";
 import { type GameData, type ProcessMsg, ProcessMsgType } from "./ipcTypes.ts";
@@ -28,6 +29,7 @@ export enum ProcState {
 
 class GameProcess {
     process: ChildProcess;
+    port: number;
 
     gameData: GameData = {
         id: "",
@@ -55,9 +57,16 @@ class GameProcess {
 
     reusedCount = 0;
 
-    constructor(manager: GameProcessManager, id: string, config: ServerGameConfig) {
+    constructor(
+        manager: GameProcessManager,
+        id: string,
+        config: ServerGameConfig,
+        port: number,
+    ) {
         this.manager = manager;
-        this.process = fork(procFile, [], {
+        this.port = port;
+
+        this.process = fork(procFile, [port.toString()], {
             serialization: "advanced",
             execArgv: procArgv,
         });
@@ -192,17 +201,23 @@ export class GameProcessManager {
 
     readonly logger = new ServerLogger("Game Process Manager");
 
+    private readonly _freePorts: number[] = [];
+
+    getNextPort() {
+        return this._freePorts.shift();
+    }
+
     constructor() {
         process.on("exit", () => {
             for (const socket of this.sockets.values()) {
                 if (socket.getUserData().closed) continue;
                 socket.end(3000, "server_restart");
             }
-
-            for (const gameProc of this.processes) {
-                gameProc.process.kill();
-            }
         });
+
+        for (let i = 0; i < Config.gameServer.maxGames; i++) {
+            this._freePorts.push(Config.gameServer.firstGamePort + i);
+        }
 
         // always keep some processes running even if theres no active games on them
         // creating a new proc is more expensive than reusing one
@@ -252,7 +267,7 @@ export class GameProcessManager {
         }, 0);
     }
 
-    newGame(config: ServerGameConfig): GameProcess {
+    newGame(config: ServerGameConfig): GameProcess | undefined {
         let gameProc: GameProcess | undefined;
 
         for (let i = 0; i < this.processes.length; i++) {
@@ -265,13 +280,21 @@ export class GameProcessManager {
 
         const id = randomUUID();
         if (!gameProc) {
-            gameProc = new GameProcess(this, id, config);
+            const port = this.getNextPort();
+            if (port === undefined) {
+                return undefined;
+            }
+            gameProc = new GameProcess(this, id, config, port);
 
             this.processes.push(gameProc);
 
             gameProc.process.on("exit", () => {
                 this.killProcess(gameProc!);
+                if (!this._freePorts.includes(gameProc!.port)) {
+                    this._freePorts.push(gameProc!.port);
+                }
             });
+
             gameProc.process.on("close", () => {
                 this.killProcess(gameProc!);
             });
@@ -313,8 +336,8 @@ export class GameProcessManager {
         return this.processById.get(id);
     }
 
-    async findGame(body: FindGamePrivateBody): Promise<GameProcess> {
-        let proc = this.processes
+    async findGame(body: FindGamePrivateBody): Promise<GameProcess | undefined> {
+        let proc: GameProcess | undefined = this.processes
             .filter((proc) => {
                 const game = proc.gameData;
                 return (
@@ -333,6 +356,10 @@ export class GameProcessManager {
                 teamMode: body.teamMode,
                 mapName: body.mapName as MapDefKey,
             });
+        }
+
+        if (!proc) {
+            return undefined;
         }
 
         // if the game has not finished creating

--- a/server/src/game/gameProcessManager.ts
+++ b/server/src/game/gameProcessManager.ts
@@ -1,9 +1,7 @@
 import { type ChildProcess, fork } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import type { WebSocket } from "uWebSockets.js";
 import { type MapDefKey, MapDefs } from "../../../shared/defs/mapDefs.ts";
 import type { TeamMode } from "../../../shared/gameConfig.ts";
-import type { GameWsDisconnectReason } from "../../../shared/types/api.ts";
 import { util } from "../../../shared/utils/util.ts";
 import { Config } from "../config.ts";
 import { ServerLogger } from "../utils/logger.ts";
@@ -109,22 +107,6 @@ class GameProcess {
                     this.state = ProcState.Idle;
                 }
                 break;
-            case ProcessMsgType.ServerSocketMsg:
-                for (let i = 0; i < msg.msgs.length; i++) {
-                    const socketMsg = msg.msgs[i];
-                    const socket = this.manager.sockets.get(socketMsg.socketId);
-
-                    if (!socket) continue;
-                    if (socket.getUserData().closed) continue;
-                    socket.send(socketMsg.data, true, false);
-                }
-                break;
-            case ProcessMsgType.SocketClose:
-                const socket = this.manager.sockets.get(msg.socketId);
-                if (socket && !socket.getUserData().closed) {
-                    socket.end(msg.reason ? 3000 : undefined, msg.reason);
-                }
-                break;
         }
     }
 
@@ -159,43 +141,9 @@ class GameProcess {
         });
         this.avaliableSlots--;
     }
-
-    handleSocketOpen(socketId: string, ip: string) {
-        this.send({
-            type: ProcessMsgType.SocketOpen,
-            socketId,
-            ip,
-        });
-    }
-
-    handleMsg(data: ArrayBuffer, socketId: string) {
-        this.send({
-            type: ProcessMsgType.ClientSocketMsg,
-            socketId,
-            data,
-        });
-    }
-
-    handleSocketClose(socketId: string) {
-        this.send({
-            type: ProcessMsgType.SocketClose,
-            socketId,
-        });
-    }
-}
-
-export interface GameSocketData {
-    gameId: string;
-    id: string;
-    closed: boolean;
-    rateLimit: Record<symbol, number>;
-    ip: string;
-    disconnectReason?: GameWsDisconnectReason;
 }
 
 export class GameProcessManager {
-    readonly sockets = new Map<string, WebSocket<GameSocketData>>();
-
     readonly processById = new Map<string, GameProcess>();
     readonly processes: GameProcess[] = [];
 
@@ -208,13 +156,6 @@ export class GameProcessManager {
     }
 
     constructor() {
-        process.on("exit", () => {
-            for (const socket of this.sockets.values()) {
-                if (socket.getUserData().closed) continue;
-                socket.end(3000, "server_restart");
-            }
-        });
-
         for (let i = 0; i < Config.gameServer.maxGames; i++) {
             this._freePorts.push(Config.gameServer.firstGamePort + i);
         }
@@ -313,13 +254,6 @@ export class GameProcessManager {
     }
 
     killProcess(gameProc: GameProcess, signal: NodeJS.Signals = "SIGTERM"): void {
-        for (const [, socket] of this.sockets) {
-            const data = socket.getUserData();
-            if (data.closed) continue;
-            if (data.gameId !== gameProc.gameData.id) continue;
-            socket.end(3000, "server_crashed");
-        }
-
         // send SIGTERM, if still hasn't terminated after 5 seconds, send SIGKILL >:3
         gameProc.process.kill(signal);
         setTimeout(() => {
@@ -376,30 +310,5 @@ export class GameProcessManager {
         proc.addJoinTokens(body.playerData, body.autoFill);
 
         return proc;
-    }
-
-    onOpen(socketId: string, socket: WebSocket<GameSocketData>): void {
-        const data = socket.getUserData();
-        const proc = this.processById.get(data.gameId);
-        if (proc === undefined) {
-            this.logger.warn("process not found, closing socket.");
-            socket.close();
-            return;
-        }
-        this.sockets.set(socketId, socket);
-        this.processById.get(data.gameId)?.handleSocketOpen(socketId, data.ip);
-    }
-
-    onMsg(socketId: string, msg: ArrayBuffer): void {
-        const data = this.sockets.get(socketId)?.getUserData();
-        if (!data) return;
-        this.processById.get(data.gameId)?.handleMsg(msg, socketId);
-    }
-
-    onClose(socketId: string) {
-        const data = this.sockets.get(socketId)?.getUserData();
-        this.sockets.delete(socketId);
-        if (!data) return;
-        this.processById.get(data.gameId)?.handleSocketClose(socketId);
     }
 }

--- a/server/src/game/ipcTypes.ts
+++ b/server/src/game/ipcTypes.ts
@@ -17,10 +17,6 @@ export enum ProcessMsgType {
     KeepAlive,
     UpdateData,
     AddJoinToken,
-    SocketOpen,
-    ClientSocketMsg,
-    ServerSocketMsg,
-    SocketClose,
 }
 
 export interface CreateGameMsg {
@@ -43,46 +39,8 @@ export interface AddJoinTokenMsg {
     tokens: FindGamePrivateBody["playerData"];
 }
 
-export interface SocketOpenMsg {
-    type: ProcessMsgType.SocketOpen;
-    socketId: string;
-    ip: string;
-}
-
-export interface SocketClientMsg {
-    type: ProcessMsgType.ClientSocketMsg;
-    socketId: string;
-    data: ArrayBuffer | Uint8Array;
-}
-
-/**
- * msgs is an array to batch all msgs created in the same game net tick
- * into the same send call
- */
-export interface SocketServerMsg {
-    type: ProcessMsgType.ServerSocketMsg;
-    msgs: Array<{
-        socketId: string;
-        data: ArrayBuffer | Uint8Array;
-    }>;
-}
-
-/**
- * Sent by the server to the game when the socket is closed
- * Or by the game to the server when the game wants to close the socket
- */
-export interface SocketCloseMsg {
-    type: ProcessMsgType.SocketClose;
-    socketId: string;
-    reason?: string;
-}
-
 export type ProcessMsg =
     | CreateGameMsg
     | KeepAliveMsg
     | UpdateDataMsg
-    | AddJoinTokenMsg
-    | SocketOpenMsg
-    | SocketClientMsg
-    | SocketServerMsg
-    | SocketCloseMsg;
+    | AddJoinTokenMsg;

--- a/server/src/gameServer.ts
+++ b/server/src/gameServer.ts
@@ -9,7 +9,7 @@ import { GameConfig } from "../../shared/gameConfig.ts";
 import type { GameWsDisconnectReason } from "../../shared/types/api.ts";
 import { Config } from "./config.ts";
 import { GameProcessManager, type GameSocketData, ProcState } from "./game/gameProcessManager.ts";
-import { apiPrivateRouter } from "./utils/apiRouter.ts";
+import { apiPrivateRouter, checkIp } from "./utils/apiRouter.ts";
 import { GIT_VERSION } from "./utils/gitRevision.ts";
 import { logErrorToWebhook, ServerLogger } from "./utils/logger.ts";
 import { HTTPRateLimit, WebSocketRateLimit } from "./utils/rateLimit.ts";
@@ -54,14 +54,22 @@ class GameServer {
             teamMode: body.teamMode,
             playerData: body.playerData,
         });
+        if (!game) {
+            return {
+                error: "full",
+            };
+        }
 
         const protocol = this.region.https ? "wss" : "ws";
-        const url = new URL(`${protocol}://${this.region.address}/play`);
-        url.searchParams.set("gameId", game.gameData.id);
+        const mainPortUrl = new URL(`${protocol}://${this.region.address}/play`);
+        mainPortUrl.searchParams.set("gameId", game.gameData.id);
+
+        const gamePortUrl = new URL(mainPortUrl.toString());
+        gamePortUrl.port = game.port.toString();
 
         return {
             gameId: game.gameData.id,
-            urls: [url.toString()],
+            urls: [gamePortUrl.toString(), mainPortUrl.toString()],
         };
     }
 
@@ -78,25 +86,6 @@ class GameServer {
         } catch (err) {
             this.logger.error(`Failed to update region: `, err);
         }
-    }
-
-    async checkIp(ip: string) {
-        try {
-            const apiRes = await apiPrivateRouter.check_ip.$post({
-                json: {
-                    ip,
-                },
-            });
-
-            if (apiRes.ok) {
-                const body = await apiRes.json();
-                return body;
-            }
-        } catch (err) {
-            this.logger.error(`Failed request API fetch_ip: `, err);
-        }
-
-        return undefined;
     }
 
     async tryToSaveLostGames() {
@@ -173,6 +162,7 @@ app.get("/private/status", (res, req) => {
                 state: ProcState[p.state],
                 reusedCount: p.reusedCount,
                 avaliableSlots: p.avaliableSlots,
+                port: p.port,
                 gameData: p.gameData,
             };
         }),
@@ -258,7 +248,7 @@ app.ws<GameSocketData>("/play", {
         const socketId = randomUUID();
         let disconnectReason: undefined | GameWsDisconnectReason = undefined;
 
-        const ipData = await server.checkIp(ip);
+        const ipData = await checkIp(ip);
 
         if (ipData?.banned) {
             disconnectReason = "ip_banned";

--- a/server/src/gameServer.ts
+++ b/server/src/gameServer.ts
@@ -1,15 +1,13 @@
 import { Cron } from "croner";
-import { randomUUID } from "node:crypto";
 import { existsSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { App, SSLApp, type WebSocket } from "uWebSockets.js";
 import pkgJson from "../../package.json" with { type: "json" };
 import { GameConfig } from "../../shared/gameConfig.ts";
-import type { GameWsDisconnectReason } from "../../shared/types/api.ts";
 import { Config } from "./config.ts";
-import { GameProcessManager, type GameSocketData, ProcState } from "./game/gameProcessManager.ts";
-import { apiPrivateRouter, checkIp } from "./utils/apiRouter.ts";
+import { GameProcessManager, ProcState } from "./game/gameProcessManager.ts";
+import { apiPrivateRouter } from "./utils/apiRouter.ts";
 import { GIT_VERSION } from "./utils/gitRevision.ts";
 import { logErrorToWebhook, ServerLogger } from "./utils/logger.ts";
 import { HTTPRateLimit, WebSocketRateLimit } from "./utils/rateLimit.ts";
@@ -69,7 +67,7 @@ class GameServer {
 
         return {
             gameId: game.gameData.id,
-            urls: [gamePortUrl.toString(), mainPortUrl.toString()],
+            urls: [gamePortUrl.toString()],
         };
     }
 
@@ -155,7 +153,6 @@ app.get("/private/status", (res, req) => {
     }
 
     uwsHelpers.returnJson(res, {
-        socketCount: server.manager.sockets.size,
         gameCount: server.manager.processes.length,
         games: server.manager.processes.map(p => {
             return {
@@ -186,122 +183,6 @@ app.post("/api/find_game", async (res, req) => {
     } catch (error) {
         server.logger.warn("/api/find_game error: ", error);
     }
-});
-
-const gameHTTPRateLimit = new HTTPRateLimit(5, 1000);
-const gameWsRateLimit = new WebSocketRateLimit(500, 1000, 5);
-
-app.ws<GameSocketData>("/play", {
-    idleTimeout: 30,
-    maxPayloadLength: 1024,
-
-    async upgrade(res, req, context): Promise<void> {
-        res.onAborted((): void => {
-            res.aborted = true;
-        });
-        const wskey = req.getHeader("sec-websocket-key");
-        const wsProtocol = req.getHeader("sec-websocket-protocol");
-        const wsExtensions = req.getHeader("sec-websocket-extensions");
-
-        const ip = uwsHelpers.getIp(res, req, Config.gameServer.proxyIPHeader);
-
-        if (!ip) {
-            server.logger.warn("Invalid IP Found:", ip);
-            res.end();
-            return;
-        }
-
-        if (gameHTTPRateLimit.isRateLimited(ip) || gameWsRateLimit.isIpRateLimited(ip)) {
-            res.cork(() => {
-                server.logger.warn("Websocket upgrade closed: Rate limited");
-                res.writeStatus("429 Too Many Requests");
-                res.write("429 Too Many Requests");
-                res.end();
-            });
-            return;
-        }
-
-        const searchParams = new URLSearchParams(req.getQuery());
-        const gameId = searchParams.get("gameId");
-
-        if (!gameId) {
-            server.logger.warn("Websocket upgrade closed: no game ID");
-            uwsHelpers.forbidden(res);
-            return;
-        }
-        const proc = server.manager.getById(gameId);
-
-        if (!proc) {
-            server.logger.warn("Websocket upgrade closed: invalid game ID");
-            uwsHelpers.forbidden(res);
-            return;
-        }
-
-        if (!proc.gameData.canJoin) {
-            server.logger.warn("Websocket upgrade closed: game already started");
-            uwsHelpers.forbidden(res);
-            return;
-        }
-
-        gameWsRateLimit.ipConnected(ip);
-
-        const socketId = randomUUID();
-        let disconnectReason: undefined | GameWsDisconnectReason = undefined;
-
-        const ipData = await checkIp(ip);
-
-        if (ipData?.banned) {
-            disconnectReason = "ip_banned";
-        } else if (ipData?.behindProxy) {
-            disconnectReason = "behind_proxy";
-        }
-
-        if (res.aborted) return;
-        res.cork(() => {
-            if (res.aborted) return;
-            res.upgrade<GameSocketData>(
-                {
-                    gameId,
-                    id: socketId,
-                    closed: false,
-                    rateLimit: {},
-                    ip,
-                    disconnectReason,
-                },
-                wskey,
-                wsProtocol,
-                wsExtensions,
-                context,
-            );
-        });
-    },
-
-    open(socket: WebSocket<GameSocketData>) {
-        const data = socket.getUserData();
-
-        if (data.disconnectReason) {
-            socket.end(data.disconnectReason ? 3000 : 0, data.disconnectReason);
-            return;
-        }
-
-        server.manager.onOpen(data.id, socket);
-    },
-
-    message(socket: WebSocket<GameSocketData>, message) {
-        if (gameWsRateLimit.isRateLimited(socket.getUserData().rateLimit)) {
-            server.logger.warn("Game websocket rate limited, closing socket.");
-            socket.end(3000, "rate_limited");
-            return;
-        }
-        server.manager.onMsg(socket.getUserData().id, message);
-    },
-
-    close(socket: WebSocket<GameSocketData>) {
-        const data = socket.getUserData();
-        data.closed = true;
-        server.manager.onClose(data.id);
-        gameWsRateLimit.ipDisconnected(data.ip);
-    },
 });
 
 const pingHTTPRateLimit = new HTTPRateLimit(1, 3000);

--- a/server/src/utils/apiRouter.ts
+++ b/server/src/utils/apiRouter.ts
@@ -2,6 +2,7 @@ import { hc } from "hono/client";
 import type { PrivateRouteApp } from "../api/routes/private/private.ts";
 import { Config } from "../config.ts";
 import { fetchWithRetry } from "./fetchWithRetry.ts";
+import { defaultLogger } from "./logger.ts";
 
 export const apiPrivateRouter = hc<PrivateRouteApp>(
     `${Config.gameServer.apiServerUrl}/private`,
@@ -12,3 +13,22 @@ export const apiPrivateRouter = hc<PrivateRouteApp>(
         },
     },
 );
+
+export async function checkIp(ip: string) {
+    try {
+        const apiRes = await apiPrivateRouter.check_ip.$post({
+            json: {
+                ip,
+            },
+        });
+
+        if (apiRes.ok) {
+            const body = await apiRes.json();
+            return body;
+        }
+    } catch (err) {
+        defaultLogger.error(`Failed request API fetch_ip: `, err);
+    }
+
+    return undefined;
+}


### PR DESCRIPTION
Should help with server lag and stutters a lot in my testing

with 20 games with around ~900 stress test bots it was completely smooth on my system, with the old main process websocket proxy it was really laggy and would stutter a lot with that amount of players, with constant lag spikes because something blocking the main server process would create a lag spike across all games for all players

Note that this is a breaking change for server hosters since they now have to open a range of ports for games (defaults to port 9000 to 9063, max of 64 games by default)

Not sure if i should still keep support for the main port proxy, its not hard to support both so i kept removing it on a separate commit