### PR TITLE
feat (matchmaking): add bounded late-join matchmaking

### DIFF
--- a/client/src/config.ts
+++ b/client/src/config.ts
@@ -100,6 +100,7 @@ const defaultConfig = {
     touchAimStyle: "anywhere" as "locked" | "anywhere",
     touchAimLine: true,
     profile: null as { slug: string } | null,
+    clientId: "",
     playerName: "",
     region: "na",
     gameModeIdx: 2,
@@ -210,6 +211,10 @@ export class ConfigManager {
     checkUpgradeConfig() {
         // validation logic
         this.config.loadout = loadout.validate(this.config.loadout);
+        if (!this.config.clientId) {
+            this.config.clientId = crypto.randomUUID();
+            this.store();
+        }
 
         // seem not to be implemeted yet
         // this.get("version");

--- a/client/src/game.ts
+++ b/client/src/game.ts
@@ -145,6 +145,7 @@ export class Game {
         matchPriv: string,
         questPriv: string,
         onConnectFail: () => void,
+        onJoinRejected?: (reason: string) => boolean,
     ) {
         if (!this.connecting && !this.connected && !this.initialized) {
             if (this.m_ws) {
@@ -202,6 +203,9 @@ export class Game {
                         onConnectFail();
                     } else if (connected && !this.m_gameOver && !displayingStats) {
                         const errMsg = this.m_disconnectMsg || "index-host-closed";
+                        if (!this.initialized && onJoinRejected?.(errMsg)) {
+                            return;
+                        }
                         this.onQuit(errMsg);
                     }
                 };

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -358,6 +358,10 @@ export class Application {
                 if (errMsg == "rate_limited") {
                     this.onJoinGameError(errMsg);
                 }
+                if (errMsg == "participant_conflict") {
+                    this.onJoinGameError("join_game_failed");
+                    return;
+                }
                 if (errMsg) {
                     this.showErrorModal(errMsg);
                     console.warn("Quitting", errMsg);
@@ -678,6 +682,7 @@ export class Application {
                 playerCount: 1,
                 autoFill: true,
                 gameModeIdx,
+                clientId: this.config.get("clientId"),
             };
 
             const tryQuickStartGameImpl = () => {
@@ -691,7 +696,7 @@ export class Application {
                             this.showIpBanModal(ban);
                             return;
                         }
-                        this.joinGame(matchData!);
+                        this.joinGame(matchData!, matchArgs);
                     });
                 });
             };
@@ -781,10 +786,14 @@ export class Application {
         );
     }
 
-    joinGame(matchData: FindGameMatchData) {
+    joinGame(
+        matchData: FindGameMatchData,
+        retryMatchArgs?: FindGameBody,
+        allowParticipantRetry = true,
+    ) {
         if (!this.game) {
             setTimeout(() => {
-                this.joinGame(matchData);
+                this.joinGame(matchData, retryMatchArgs, allowParticipantRetry);
             }, 250);
             return;
         }
@@ -809,6 +818,34 @@ export class Application {
                 matchData.data,
                 this.account.questPriv,
                 onFailure,
+                (reason) => {
+                    if (
+                        reason !== "participant_conflict"
+                        || !retryMatchArgs
+                        || !allowParticipantRetry
+                    ) {
+                        return false;
+                    }
+
+                    const excludeGameIds = [
+                        ...(retryMatchArgs.excludeGameIds ?? []),
+                        matchData.gameId,
+                    ];
+                    const nextMatchArgs = {
+                        ...retryMatchArgs,
+                        excludeGameIds,
+                    };
+
+                    this.findGame(nextMatchArgs, (err, nextMatchData, ban) => {
+                        if (err || ban || !nextMatchData) {
+                            this.onJoinGameError(err ?? "join_game_failed");
+                            return;
+                        }
+                        this.joinGame(nextMatchData, nextMatchArgs, false);
+                    });
+
+                    return true;
+                },
             );
         };
         joinGameImpl(urls, matchData);
@@ -820,6 +857,7 @@ export class Application {
             invalid_protocol: this.localization.translate("index-invalid-protocol"),
             invalid_captcha: this.localization.translate("index-invalid-captcha"),
             join_game_failed: this.localization.translate("index-failed-joining-game"),
+            participant_conflict: this.localization.translate("index-failed-joining-game"),
             rate_limited: this.localization.translate("index-rate-limited"),
         };
         if (err == "invalid_protocol") {

--- a/client/src/ui/teamMenu.ts
+++ b/client/src/ui/teamMenu.ts
@@ -189,6 +189,7 @@ export class TeamMenu {
             // Load properties from config
             this.playerData = {
                 name: this.config.get("playerName"),
+                clientId: this.config.get("clientId"),
             };
             this.roomData = {
                 roomUrl,

--- a/config.ts
+++ b/config.ts
@@ -60,6 +60,14 @@ export function getConfig(isProduction: boolean, dir: string) {
         },
         captchaEnabled: false,
         cachingEnabled: false,
+        matchmaking: {
+            lateJoinEnabled: true,
+            earlyJoinWindowSeconds: 60,
+            lateJoinMaxStartedTime: 120,
+            lateJoinMaxGasCircleIdx: 0,
+            lateJoinMinAliveCount: 4,
+            lateJoinTargetPlayers: 10,
+        },
         rateLimitsEnabled: isProduction,
         uniqueInGameNames: true,
         debug: {

--- a/configType.ts
+++ b/configType.ts
@@ -317,6 +317,42 @@ export interface ConfigType {
     cachingEnabled: boolean;
 
     /**
+     * Matchmaking behavior.
+     */
+    matchmaking: {
+        /**
+         * Allows fresh players to join already-started low-population games.
+         */
+        lateJoinEnabled: boolean;
+
+        /**
+         * Original early join window, also used by gameplay systems that should not
+         * be extended by late-join matchmaking.
+         */
+        earlyJoinWindowSeconds: number;
+
+        /**
+         * Latest started-game age, in seconds, that late join can target.
+         */
+        lateJoinMaxStartedTime: number;
+
+        /**
+         * Latest gas circle index that late join can target.
+         */
+        lateJoinMaxGasCircleIdx: number;
+
+        /**
+         * Do not late-join games already collapsing into endgame.
+         */
+        lateJoinMinAliveCount: number;
+
+        /**
+         * Stop backfilling started games once they reach this many alive players.
+         */
+        lateJoinTargetPlayers: number;
+    };
+
+    /**
      * If the turnstile captcha state is enabled.
      * Used by the API server and will be returned on site_info API.
      *

--- a/server/src/api/apiHelpers.ts
+++ b/server/src/api/apiHelpers.ts
@@ -39,7 +39,10 @@ export async function verifyTurnsStile(token: string, ip: string): Promise<boole
 }
 
 export async function getFindGamePlayerData(
-    players: Pick<FindGamePrivateBody["playerData"][number], "token" | "userId" | "ip">[],
+    players: Pick<
+        FindGamePrivateBody["playerData"][number],
+        "token" | "userId" | "ip" | "clientId"
+    >[],
 ): Promise<FindGamePrivateBody["playerData"]> {
     const userIds = [
         ...new Set(players.map((p) => p.userId).filter((id) => id !== null)),
@@ -70,10 +73,11 @@ export async function getFindGamePlayerData(
         accountData = Object.fromEntries(query.map((r) => [r.userId, r]));
     }
 
-    return players.map(({ token, userId, ip }) => ({
+    return players.map(({ token, userId, ip, clientId }) => ({
         token,
         userId,
         ip,
+        clientId,
         loadout: userId ? accountData[userId]?.loadout : undefined,
         quests: userId ? (accountData[userId]?.quests ?? []) : [],
     }));

--- a/server/src/api/index.ts
+++ b/server/src/api/index.ts
@@ -161,6 +161,7 @@ app.post("/api/find_game", validateParams(zFindGameBody), async (c) => {
             token,
             userId: user?.id || null,
             ip,
+            clientId: body.clientId,
         },
     ]);
 
@@ -170,6 +171,7 @@ app.post("/api/find_game", validateParams(zFindGameBody), async (c) => {
         mapName: mode.mapName,
         teamMode: mode.teamMode,
         autoFill: true,
+        excludeGameIds: body.excludeGameIds,
         playerData,
     });
 

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -5,6 +5,11 @@ import { math } from "../../../shared/utils/math.ts";
 import { v2 } from "../../../shared/utils/v2.ts";
 import { Config } from "../config.ts";
 import { ServerLogger } from "../utils/logger.ts";
+import {
+    getParticipantKeys,
+    hasParticipantConflict,
+    type ParticipantRecord,
+} from "../utils/matchmaking.ts";
 import { type FindGamePrivateBody, type ServerGameConfig } from "../utils/types.ts";
 import { GameModeManager } from "./gameModeManager.ts";
 import { Grid } from "./grid.ts";
@@ -28,7 +33,9 @@ import type { ClientSocket } from "./socket.ts";
 export interface JoinTokenData {
     expiresAt: number;
     userId: string | null;
+    clientId?: string;
     findGameIp: string;
+    reservationId: string;
     loadout?: Loadout;
     quests?: string[];
     groupData: {
@@ -66,6 +73,7 @@ export class Game {
     netSyncWarnings = 0;
 
     joinTokens = new Map<string, JoinTokenData>();
+    participantRecords = new Map<string, string>();
 
     get aliveCount(): number {
         return this.playerBarn.livingPlayers.length;
@@ -331,12 +339,71 @@ export class Game {
         }
     }
 
-    get canJoin(): boolean {
+    get maxPlayers(): number {
+        return this.map.mapDef.gameMode.maxPlayers;
+    }
+
+    get participantRecordList(): ParticipantRecord[] {
+        return Array.from(this.participantRecords.entries()).map(([key, reservationId]) => ({
+            key,
+            reservationId,
+        }));
+    }
+
+    get isEarlyJoinWindowOpen(): boolean {
         return (
-            this.aliveCount < this.map.mapDef.gameMode.maxPlayers
+            this.aliveCount < this.maxPlayers
             && !this.over
-            && this.startedTime < 60
+            && !this.stopped
+            && this.startedTime < Config.matchmaking.earlyJoinWindowSeconds
         );
+    }
+
+    get canAcceptMatchmakingPlayers(): boolean {
+        if (this.aliveCount >= this.maxPlayers || this.over || this.stopped) return false;
+        if (this.isEarlyJoinWindowOpen) return true;
+        if (!Config.matchmaking.lateJoinEnabled || !this.started) return false;
+
+        const targetPlayers = Math.min(
+            this.maxPlayers,
+            Config.matchmaking.lateJoinTargetPlayers,
+        );
+        return (
+            this.startedTime <= Config.matchmaking.lateJoinMaxStartedTime
+            && this.gas.circleIdx <= Config.matchmaking.lateJoinMaxGasCircleIdx
+            && this.aliveCount >= Config.matchmaking.lateJoinMinAliveCount
+            && this.aliveCount < targetPlayers
+        );
+    }
+
+    get canUpdateGroupSpawnAnchor(): boolean {
+        return this.isEarlyJoinWindowOpen;
+    }
+
+    get canJoin(): boolean {
+        return this.canAcceptMatchmakingPlayers;
+    }
+
+    getJoinTokenParticipantKeys(joinData: JoinTokenData): string[] {
+        return getParticipantKeys({
+            userId: joinData.userId,
+            clientId: joinData.clientId,
+            ip: joinData.findGameIp,
+        });
+    }
+
+    hasParticipantConflict(joinData: JoinTokenData): boolean {
+        return hasParticipantConflict(
+            this.participantRecordList,
+            this.getJoinTokenParticipantKeys(joinData),
+            joinData.reservationId,
+        );
+    }
+
+    registerParticipant(joinData: JoinTokenData) {
+        for (const key of this.getJoinTokenParticipantKeys(joinData)) {
+            this.participantRecords.set(key, joinData.reservationId);
+        }
     }
 
     deserializeMsg(buff: ArrayBuffer): {
@@ -540,7 +607,11 @@ export class Game {
         }
     }
 
-    addJoinTokens(tokens: FindGamePrivateBody["playerData"], autoFill: boolean) {
+    addJoinTokens(
+        tokens: FindGamePrivateBody["playerData"],
+        autoFill: boolean,
+        reservationId: string,
+    ) {
         const groupData = {
             playerCount: tokens.length,
             groupHashToJoin: "",
@@ -551,6 +622,8 @@ export class Game {
             this.joinTokens.set(token.token, {
                 expiresAt: Date.now() + 10000,
                 userId: token.userId,
+                clientId: token.clientId,
+                reservationId,
                 groupData,
                 findGameIp: token.ip,
                 loadout: token.loadout,
@@ -558,6 +631,8 @@ export class Game {
             });
         }
     }
+
+    notifyJoinTokenConsumed(_token: string) {}
 
     stop() {
         if (this.stopped) return;

--- a/server/src/game/gameProcess.ts
+++ b/server/src/game/gameProcess.ts
@@ -22,14 +22,22 @@ class ServerGame extends Game {
             id: this.id,
             teamMode: this.teamMode,
             mapName: this.mapName,
-            canJoin: this.canJoin,
+            canJoin: this.canAcceptMatchmakingPlayers,
             aliveCount: this.aliveCount,
             startedTime: this.startedTime,
             stopped: this.stopped,
+            participantRecords: this.participantRecordList,
         });
         if (this.stopped) {
             game = undefined;
         }
+    }
+
+    override notifyJoinTokenConsumed(token: string) {
+        sendMsg({
+            type: ProcessMsgType.JoinTokenConsumed,
+            token,
+        });
     }
 
     override async sendQuestProgress(userId: string, progress: Array<{ id: string; delta: number }>) {
@@ -214,7 +222,7 @@ process.on("message", (msg: ProcessMsg) => {
 
     switch (msg.type) {
         case ProcessMsgType.AddJoinToken:
-            game.addJoinTokens(msg.tokens, msg.autoFill);
+            game.addJoinTokens(msg.tokens, msg.autoFill, msg.reservationId);
             break;
         case ProcessMsgType.SocketOpen: {
             const socket = new ProcessSocket<Player | undefined>(msg.socketId, msg.ip);

--- a/server/src/game/gameProcessManager.ts
+++ b/server/src/game/gameProcessManager.ts
@@ -6,6 +6,11 @@ import type { TeamMode } from "../../../shared/gameConfig.ts";
 import * as net from "../../../shared/net/net.ts";
 import { util } from "../../../shared/utils/util.ts";
 import { ServerLogger } from "../utils/logger.ts";
+import {
+    getParticipantKeys,
+    hasParticipantConflict,
+    type ParticipantRecord,
+} from "../utils/matchmaking.ts";
 import { type FindGamePrivateBody, type ServerGameConfig } from "../utils/types.ts";
 import { type GameData, type ProcessMsg, ProcessMsgType } from "./ipcTypes.ts";
 
@@ -33,6 +38,7 @@ class GameProcess {
         aliveCount: 0,
         startedTime: 0,
         stopped: false,
+        participantRecords: [],
     };
 
     state = ProcState.Idle;
@@ -46,7 +52,14 @@ class GameProcess {
 
     onCreatedCbs: Array<(_proc: typeof this) => void> = [];
 
-    avaliableSlots = 0;
+    pendingReservations = new Map<
+        string,
+        {
+            expiresAt: number;
+            reservationId: string;
+            keys: string[];
+        }
+    >();
 
     reusedCount = 0;
 
@@ -93,6 +106,9 @@ class GameProcess {
                     this.state = ProcState.Idle;
                 }
                 break;
+            case ProcessMsgType.JoinTokenConsumed:
+                this.pendingReservations.delete(msg.token);
+                break;
             case ProcessMsgType.ServerSocketMsg:
                 for (let i = 0; i < msg.msgs.length; i++) {
                     const socketMsg = msg.msgs[i];
@@ -133,22 +149,98 @@ class GameProcess {
         this.gameData.id = id;
         this.gameData.teamMode = config.teamMode;
         this.gameData.mapName = config.mapName;
+        this.gameData.canJoin = false;
+        this.gameData.aliveCount = 0;
+        this.gameData.startedTime = 0;
         this.gameData.stopped = false;
+        this.gameData.participantRecords = [];
+        this.pendingReservations.clear();
         this.state = ProcState.CreatingGame;
-
-        const mapDef = MapDefs[this.gameData.mapName as MapDefKey];
-        this.avaliableSlots = mapDef.gameMode.maxPlayers;
 
         this.reusedCount++;
     }
 
-    addJoinTokens(tokens: FindGamePrivateBody["playerData"], autoFill: boolean) {
+    get maxPlayers(): number {
+        const mapDef = MapDefs[this.gameData.mapName as MapDefKey];
+        return mapDef.gameMode.maxPlayers;
+    }
+
+    cleanupPendingReservations(now = Date.now()) {
+        for (const [token, reservation] of this.pendingReservations) {
+            if (reservation.expiresAt <= now) {
+                this.pendingReservations.delete(token);
+            }
+        }
+    }
+
+    get activePendingReservations(): number {
+        this.cleanupPendingReservations();
+        return this.pendingReservations.size;
+    }
+
+    get availableSlots(): number {
+        return this.maxPlayers - this.gameData.aliveCount - this.activePendingReservations;
+    }
+
+    get effectivePopulation(): number {
+        return this.gameData.aliveCount + this.activePendingReservations;
+    }
+
+    get participantAndPendingRecords(): ParticipantRecord[] {
+        this.cleanupPendingReservations();
+        const records = [...this.gameData.participantRecords];
+        for (const reservation of this.pendingReservations.values()) {
+            for (const key of reservation.keys) {
+                records.push({
+                    key,
+                    reservationId: reservation.reservationId,
+                });
+            }
+        }
+        return records;
+    }
+
+    hasParticipantConflict(body: FindGamePrivateBody & { reservationId: string }): boolean {
+        const records = this.participantAndPendingRecords;
+        const seenNonIpKeys = new Set<string>();
+
+        for (const player of body.playerData) {
+            const keys = getParticipantKeys(player);
+
+            for (const key of keys) {
+                if (key.startsWith("ip:")) continue;
+                if (seenNonIpKeys.has(key)) return true;
+                seenNonIpKeys.add(key);
+            }
+
+            if (hasParticipantConflict(records, keys, body.reservationId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    addJoinTokens(
+        tokens: FindGamePrivateBody["playerData"],
+        autoFill: boolean,
+        reservationId: string,
+    ) {
+        const expiresAt = Date.now() + 12000;
+        for (const token of tokens) {
+            this.pendingReservations.set(token.token, {
+                expiresAt,
+                reservationId,
+                keys: getParticipantKeys(token),
+            });
+        }
+
         this.send({
             type: ProcessMsgType.AddJoinToken,
             autoFill,
             tokens,
+            reservationId,
         });
-        this.avaliableSlots--;
     }
 
     handleSocketOpen(socketId: string, ip: string) {
@@ -309,24 +401,39 @@ export class GameProcessManager {
     }
 
     async findGame(body: FindGamePrivateBody): Promise<GameProcess> {
+        const request = {
+            ...body,
+            reservationId: body.reservationId ?? randomUUID(),
+        };
+
         let proc = this.processes
             .filter((proc) => {
                 const game = proc.gameData;
+                const excluded = request.excludeGameIds?.includes(game.id);
                 return (
+                    !excluded
+                    &&
                     (game.canJoin || proc.state === ProcState.CreatingGame)
-                    && proc.avaliableSlots > 0
-                    && game.teamMode === body.teamMode
-                    && game.mapName === body.mapName
+                    && proc.availableSlots >= request.playerData.length
+                    && !proc.hasParticipantConflict(request)
+                    && game.teamMode === request.teamMode
+                    && game.mapName === request.mapName
                 );
             })
             .sort((a, b) => {
-                return a.gameData.startedTime - b.gameData.startedTime;
+                const populationDiff = b.effectivePopulation - a.effectivePopulation;
+                if (populationDiff) return populationDiff;
+
+                const startedDiff = a.gameData.startedTime - b.gameData.startedTime;
+                if (startedDiff) return startedDiff;
+
+                return a.gameData.id.localeCompare(b.gameData.id);
             })[0];
 
         if (!proc) {
             proc = this.newGame({
-                teamMode: body.teamMode,
-                mapName: body.mapName as MapDefKey,
+                teamMode: request.teamMode,
+                mapName: request.mapName as MapDefKey,
             });
         }
 
@@ -335,13 +442,17 @@ export class GameProcessManager {
         if (proc.state !== ProcState.Running) {
             return await new Promise((resolve) => {
                 proc.onCreatedCbs.push((proc) => {
-                    proc.addJoinTokens(body.playerData, body.autoFill);
+                    proc.addJoinTokens(
+                        request.playerData,
+                        request.autoFill,
+                        request.reservationId,
+                    );
                     resolve(proc);
                 });
             });
         }
 
-        proc.addJoinTokens(body.playerData, body.autoFill);
+        proc.addJoinTokens(request.playerData, request.autoFill, request.reservationId);
 
         return proc;
     }

--- a/server/src/game/group.ts
+++ b/server/src/game/group.ts
@@ -185,7 +185,7 @@ export class Team extends BasePlayerGroup {
             (p) => !p.downed && !p.disconnected,
         );
 
-        if (playersToPromote.length > 2 || this.game.canJoin) return;
+        if (playersToPromote.length > 2 || this.game.isEarlyJoinWindowOpen) return;
 
         const last1 = playersToPromote[0];
         const last2 = playersToPromote[1];

--- a/server/src/game/ipcTypes.ts
+++ b/server/src/game/ipcTypes.ts
@@ -9,6 +9,10 @@ export interface GameData {
     aliveCount: number;
     startedTime: number;
     stopped: boolean;
+    participantRecords: Array<{
+        key: string;
+        reservationId: string;
+    }>;
 }
 
 export enum ProcessMsgType {
@@ -21,6 +25,7 @@ export enum ProcessMsgType {
     ClientSocketMsg,
     ServerSocketMsg,
     SocketClose,
+    JoinTokenConsumed,
 }
 
 export interface CreateGameMsg {
@@ -45,6 +50,7 @@ export interface AddJoinTokenMsg {
     type: ProcessMsgType.AddJoinToken;
     autoFill: boolean;
     tokens: FindGamePrivateBody["playerData"];
+    reservationId: string;
 }
 
 export interface SocketOpenMsg {
@@ -81,6 +87,11 @@ export interface SocketCloseMsg {
     reason?: string;
 }
 
+export interface JoinTokenConsumedMsg {
+    type: ProcessMsgType.JoinTokenConsumed;
+    token: string;
+}
+
 export type ProcessMsg =
     | CreateGameMsg
     | GameCreatedMsg
@@ -90,4 +101,5 @@ export type ProcessMsg =
     | SocketOpenMsg
     | SocketClientMsg
     | SocketServerMsg
-    | SocketCloseMsg;
+    | SocketCloseMsg
+    | JoinTokenConsumedMsg;

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -147,12 +147,19 @@ export class PlayerBarn {
         if (!joinData || joinData.expiresAt < Date.now()) {
             this.game.logger.warn("player tried to join without or with expired join token");
             socket.close();
+            this.game.notifyJoinTokenConsumed(joinMsg.matchPriv);
             if (joinData) {
                 this.game.joinTokens.delete(joinMsg.matchPriv);
             }
             return;
         }
         this.game.joinTokens.delete(joinMsg.matchPriv);
+        this.game.notifyJoinTokenConsumed(joinMsg.matchPriv);
+
+        if (this.game.hasParticipantConflict(joinData)) {
+            socket.closeWithReason("participant_conflict");
+            return;
+        }
 
         if (Config.rateLimitsEnabled) {
             const count = this.livingPlayers.filter(
@@ -219,6 +226,7 @@ export class PlayerBarn {
             joinData.quests,
         );
 
+        this.game.registerParticipant(joinData);
         this.activatePlayer(player, group, team);
         player.setLoadout(
             joinData.loadout ? joinData.loadout : joinMsg.loadout,
@@ -501,7 +509,11 @@ export class PlayerBarn {
         if (!group && groupData.autoFill) {
             const groups = team ? team.getGroups() : this.groups;
             group = groups.find((group) => {
-                return group.autoFill && group.canJoin(groupData.playerCount);
+                return (
+                    this.game.isEarlyJoinWindowOpen
+                    && group.autoFill
+                    && group.canJoin(groupData.playerCount)
+                );
             });
         }
 
@@ -2037,7 +2049,7 @@ export class Player extends BaseGameObject {
         // if we are in a valid spawn position (not on water, inside a building, etc)
         if (
             this.group?.players[0] === this
-            && this.game.canJoin
+            && this.game.canUpdateGroupSpawnAnchor
             && this.group.players.length < this.group.maxPlayers
         ) {
             this.group.spawnPositionTicker -= dt;

--- a/server/src/teamMenu.ts
+++ b/server/src/teamMenu.ts
@@ -62,6 +62,7 @@ class Player {
     disconnectTimeout: ReturnType<typeof setTimeout>;
 
     encodedIp: string;
+    clientId?: string;
 
     constructor(
         public socket: WSContext<SocketData>,
@@ -251,6 +252,7 @@ class Room {
                     token,
                     userId: player.userId,
                     ip: player.ip,
+                    clientId: player.clientId,
                 } satisfies FindGamePrivateBody["playerData"][0];
             }),
         );
@@ -546,6 +548,7 @@ export class TeamMenu {
                     }
 
                     player.setName(msg.data.playerData.name);
+                    player.clientId = msg.data.playerData.clientId;
 
                     const room = this.createRoom(msg.data.roomData);
                     room.addPlayer(player);
@@ -564,6 +567,7 @@ export class TeamMenu {
                         break;
                     }
                     player.setName(msg.data.playerData.name);
+                    player.clientId = msg.data.playerData.clientId;
 
                     room.addPlayer(player);
                 }

--- a/server/src/utils/matchmaking.ts
+++ b/server/src/utils/matchmaking.ts
@@ -1,0 +1,43 @@
+import type { FindGamePrivateBody } from "./types.ts";
+
+export interface ParticipantRecord {
+    key: string;
+    reservationId: string;
+}
+
+const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function normalizeClientId(clientId?: string): string | undefined {
+    if (!clientId || !uuidRegex.test(clientId)) return undefined;
+    return clientId.toLowerCase();
+}
+
+export function normalizeIp(ip: string): string {
+    return ip.toLowerCase();
+}
+
+export function getParticipantKeys(
+    player: Pick<FindGamePrivateBody["playerData"][number], "userId" | "clientId" | "ip">,
+): string[] {
+    const keys = [`ip:${normalizeIp(player.ip)}`];
+    const clientId = normalizeClientId(player.clientId);
+    if (player.userId) keys.push(`user:${player.userId}`);
+    if (clientId) keys.push(`client:${clientId}`);
+    return keys;
+}
+
+export function hasParticipantConflict(
+    records: Iterable<ParticipantRecord>,
+    keys: Iterable<string>,
+    reservationId: string,
+): boolean {
+    const candidateKeys = new Set(keys);
+    for (const record of records) {
+        if (!candidateKeys.has(record.key)) continue;
+        if (record.key.startsWith("ip:") && record.reservationId === reservationId) {
+            continue;
+        }
+        return true;
+    }
+    return false;
+}

--- a/server/src/utils/types.ts
+++ b/server/src/utils/types.ts
@@ -38,11 +38,14 @@ export const zFindGamePrivateBody = z.object({
     autoFill: z.boolean(),
     mapName: z.string(),
     teamMode: z.number(),
+    reservationId: z.string().optional(),
+    excludeGameIds: z.array(z.string()).optional(),
     playerData: z.array(
         z.object({
             token: z.string(),
             userId: z.string().nullable(),
             ip: z.string(),
+            clientId: z.string().optional(),
             loadout: loadoutSchema.optional(),
             quests: z.array(z.string()).optional(),
         }),

--- a/shared/types/api.ts
+++ b/shared/types/api.ts
@@ -10,6 +10,8 @@ export const zFindGameBody = z.object({
     autoFill: z.boolean(),
     gameModeIdx: z.number(),
     turnstileToken: z.string().optional(),
+    clientId: z.string().optional(),
+    excludeGameIds: z.array(z.string()).optional(),
 });
 
 export type FindGameBody = z.infer<typeof zFindGameBody>;
@@ -47,6 +49,7 @@ export type FindGameError =
     | "full"
     | "invalid_protocol"
     | "join_game_failed"
+    | "participant_conflict"
     | "rate_limited"
     | "banned"
     | "behind_proxy"

--- a/shared/types/team.ts
+++ b/shared/types/team.ts
@@ -111,6 +111,7 @@ export const zTeamJoinMsg = z.object({
         roomUrl: z.string(),
         playerData: z.object({
             name: z.string(),
+            clientId: z.string().optional(),
         }),
     }),
 });
@@ -138,6 +139,7 @@ export const zTeamCreateMsg = z.object({
         roomData: zClientRoomData,
         playerData: z.object({
             name: z.string(),
+            clientId: z.string().optional(),
         }),
     }),
 });

--- a/tests/src/matchmaking.test.ts
+++ b/tests/src/matchmaking.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { TeamMode } from "../../shared/gameConfig.ts";
+import { Config } from "../../server/src/config.ts";
+import type { JoinTokenData } from "../../server/src/game/game.ts";
+import {
+    hasParticipantConflict,
+    type ParticipantRecord,
+} from "../../server/src/utils/matchmaking.ts";
+import { createGame } from "./gameTestHelpers.ts";
+
+const originalMatchmakingConfig = { ...Config.matchmaking };
+
+afterEach(() => {
+    Object.assign(Config.matchmaking, originalMatchmakingConfig);
+});
+
+function addPlayers(count: number) {
+    const game = createGame(TeamMode.Solo, "test_normal");
+    for (let i = 0; i < count; i++) {
+        game.playerBarn.addTestPlayer({});
+    }
+    return game;
+}
+
+function joinData(params: Partial<JoinTokenData>): JoinTokenData {
+    return {
+        expiresAt: Date.now() + 10000,
+        userId: null,
+        findGameIp: "127.0.0.1",
+        reservationId: "reservation-a",
+        groupData: {
+            autoFill: true,
+            playerCount: 1,
+            groupHashToJoin: "",
+        },
+        ...params,
+    };
+}
+
+describe("late-join matchmaking", () => {
+    it("keeps the original early join window separate from late matchmaking", () => {
+        const game = addPlayers(4);
+
+        game.started = true;
+        game.startedTime = Config.matchmaking.earlyJoinWindowSeconds + 1;
+        game.gas.circleIdx = 0;
+
+        expect(game.isEarlyJoinWindowOpen).toBe(false);
+        expect(game.canUpdateGroupSpawnAnchor).toBe(false);
+        expect(game.canAcceptMatchmakingPlayers).toBe(true);
+    });
+
+    it("does not late-join games that are too old, too small, or past the gas limit", () => {
+        const tooSmall = addPlayers(Config.matchmaking.lateJoinMinAliveCount - 1);
+        tooSmall.started = true;
+        tooSmall.startedTime = Config.matchmaking.earlyJoinWindowSeconds + 1;
+        tooSmall.gas.circleIdx = 0;
+        expect(tooSmall.canAcceptMatchmakingPlayers).toBe(false);
+
+        const tooOld = addPlayers(Config.matchmaking.lateJoinMinAliveCount);
+        tooOld.started = true;
+        tooOld.startedTime = Config.matchmaking.lateJoinMaxStartedTime + 1;
+        tooOld.gas.circleIdx = 0;
+        expect(tooOld.canAcceptMatchmakingPlayers).toBe(false);
+
+        const tooLateGas = addPlayers(Config.matchmaking.lateJoinMinAliveCount);
+        tooLateGas.started = true;
+        tooLateGas.startedTime = Config.matchmaking.earlyJoinWindowSeconds + 1;
+        tooLateGas.gas.circleIdx = Config.matchmaking.lateJoinMaxGasCircleIdx + 1;
+        expect(tooLateGas.canAcceptMatchmakingPlayers).toBe(false);
+    });
+
+    it("records participant identities permanently for a match", () => {
+        const game = addPlayers(1);
+        const firstJoin = joinData({
+            userId: "user-1",
+            clientId: "11111111-1111-4111-8111-111111111111",
+            findGameIp: "127.0.0.10",
+            reservationId: "reservation-a",
+        });
+
+        game.registerParticipant(firstJoin);
+
+        expect(game.hasParticipantConflict(joinData({ userId: "user-1" }))).toBe(true);
+        expect(
+            game.hasParticipantConflict(
+                joinData({
+                    clientId: "11111111-1111-4111-8111-111111111111",
+                    findGameIp: "127.0.0.20",
+                    reservationId: "reservation-b",
+                }),
+            ),
+        ).toBe(true);
+        expect(
+            game.hasParticipantConflict(
+                joinData({
+                    findGameIp: "127.0.0.10",
+                    reservationId: "reservation-b",
+                }),
+            ),
+        ).toBe(true);
+    });
+
+    it("allows same-reservation IP matches but blocks later IP re-entry", () => {
+        const records: ParticipantRecord[] = [
+            {
+                key: "ip:127.0.0.10",
+                reservationId: "reservation-a",
+            },
+        ];
+        const keys = ["ip:127.0.0.10"];
+
+        expect(hasParticipantConflict(records, keys, "reservation-a")).toBe(false);
+        expect(hasParticipantConflict(records, keys, "reservation-b")).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
Adds bounded late-join matchmaking so low-population matches can consolidate into active games without allowing dead players to respawn into the same match.

## Changes
- split early join behavior from late matchmaking eligibility
- add conservative late-join limits for time, gas circle, alive count, and target population
- replace the old monotonic available-slot counter with pending reservation accounting
- track participant identities by user ID, client ID, and IP for each match
- reject duplicate participant joins with a visible client-side path
- add a persisted anonymous client ID and send it through solo/team matchmaking
- add regression tests for late-join eligibility and participant conflict behavior

## Testing
- `pnpm run build` passed
- `pnpm --dir tests exec vitest src/matchmaking.test.ts` passed
- Full `pnpm --dir tests test` still has unrelated existing SVG size failures for:
  - `client/public/img/map/map-bush-06.svg`
  - `client/public/img/map/map-bush-06tr.svg`