### PR TITLE
Filter out AFK players on 50v50 promotions

### DIFF
--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -348,9 +348,44 @@ export class PlayerBarn {
                     );
                     if (promotablePlayers.length == 0) continue;
 
-                    const randomPlayer = promotablePlayers[
-                        util.randomInt(0, promotablePlayers.length - 1)
-                    ];
+                    // logic to combat people joining with multiple tabs to role farm
+                    const activePromotablePlayers = promotablePlayers.filter((player) => {
+                        const total = player.movingTicker + player.stayingStillTicker;
+                        if (total > 5) {
+                            // for players alive for more than 5 seconds, filter out the ones that have stayed still
+                            // for over 50% of the time
+                            const timeAfk = player.stayingStillTicker / total;
+                            if (timeAfk > 0.5) {
+                                return false;
+                            }
+                        }
+                        // also filter out players that haven't moved for the last 5 seconds
+                        if (player.timeWithoutMoving > 5) {
+                            return false;
+                        }
+
+                        // for people joining with the same account
+                        // only count their first join thats still connected
+                        if (player.userId) {
+                            const playersWithThisAccount = this.livingPlayers.filter(otherPlayer => {
+                                return !otherPlayer.disconnected && otherPlayer.userId === player.userId;
+                            });
+                            const thisIdx = playersWithThisAccount.indexOf(player);
+                            if (thisIdx !== 0) return false;
+                        }
+
+                        return true;
+                    });
+
+                    // if we don't have any active player to be promoted
+                    // then no harm in promoting possibly AFK players...
+                    const finalPlayers = activePromotablePlayers.length === 0
+                        ? promotablePlayers
+                        : activePromotablePlayers;
+
+                    if (!finalPlayers.length) continue;
+
+                    const randomPlayer = util.randomItem(finalPlayers)!;
                     randomPlayer.promoteToRole(scheduledRole.role);
                 }
             }
@@ -691,6 +726,11 @@ export class Player extends BaseGameObject {
 
     speed: number = 0;
     moveVel = v2.create(0, 0);
+
+    // used to filter out AFK players on 50v50 role promotions
+    movingTicker = 0;
+    stayingStillTicker = 0;
+    timeWithoutMoving = 0;
 
     shotSlowdownTimer: number = 0;
 
@@ -1987,10 +2027,17 @@ export class Player extends BaseGameObject {
         const hasTreeClimbing = this.hasPerk("tree_climbing");
 
         let steps: number;
-        if (movement.x !== 0 || movement.y !== 0) {
+
+        if (!v2.eq(movement, v2.create(0, 0))) {
             this.recalculateSpeed(hasTreeClimbing);
             steps = Math.round(math.max(this.speed * dt + 5, 5));
+
+            this.movingTicker += dt;
+            this.timeWithoutMoving = 0;
         } else {
+            this.timeWithoutMoving += dt;
+            this.stayingStillTicker += dt;
+
             this.speed = 0;
             steps = 1;
         }

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -2021,8 +2021,10 @@ export class Player extends BaseGameObject {
 
         v2.set(this.posOld, this.pos);
 
-        v2.set(this.vel, v2.mul(this.vel, 1 / (1 + dt * 4)));
-        v2.set(this.pos, v2.add(this.pos, v2.mul(this.vel, dt)));
+        if (!v2.eq(this.vel, v2.create(0, 0), 0.01)) {
+            v2.set(this.vel, v2.mul(this.vel, 1 / (1 + dt * 4)));
+            v2.set(this.pos, v2.add(this.pos, v2.mul(this.vel, dt)));
+        }
 
         const hasTreeClimbing = this.hasPerk("tree_climbing");
 


### PR DESCRIPTION
This adds 3 different filters to remove AFK players:

- AFK ratio: If the player is alive for over 5 seconds and didn't move for 50% of the time they get filtered out
- Last movement time: If the player has not moved in the last 5 seconds they get filtered out
- Same account check: Filters out all connected players with the same userId except the first one to join

Note: it still uses the old list if no players match those conditions, so on low player count servers AFK players will still get promoted, since there's no harm in promoting an AFK player if they aren't stealing the spot of an active player