### PR TITLE
fix: force switch to melee slot when downed

### DIFF
--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -3009,7 +3009,7 @@ export class Player extends BaseGameObject {
         this.cancelAction();
 
         this.weaponManager.throwThrowable();
-        this.weaponManager.setCurWeapIndex(GameConfig.WeaponSlot.Melee);
+        this.weaponManager.setCurWeapIndex(GameConfig.WeaponSlot.Melee, true);
 
         if (this.weapons[GameConfig.WeaponSlot.Melee].type === "pan") {
             this.wearingPan = true;


### PR DESCRIPTION
mentioned in: https://discord.com/channels/1407084649343352852/1520707991823847535
also fixes the related bug where the burst bullets don't get removed from their queue after being downed, so when revived they will continue shooting out the rest of the burst
