### PR TITLE
fix: prevent race condition causing landing effects to not be played

### DIFF
--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -301,7 +301,6 @@ export class Game {
         this.lootBarn.flush();
         this.planeBarn.flush();
         this.bulletBarn.flush();
-        this.airdropBarn.flush();
         this.objectRegister.flush();
         this.explosionBarn.flush();
         this.gas.flush();

--- a/server/src/game/objects/airdrop.ts
+++ b/server/src/game/objects/airdrop.ts
@@ -25,9 +25,12 @@ export class AirdropBarn {
         for (let i = 0; i < this.airdrops.length; i++) {
             const airdrop = this.airdrops[i];
             if (airdrop.sentLandedToClients) {
-                this.airdrops.splice(i, 1);
-                i--;
-                airdrop.destroy();
+                airdrop.fallTime -= dt;
+                if (airdrop.fallTime <= -1.0) {
+                    this.airdrops.splice(i, 1);
+                    i--;
+                    airdrop.destroy();
+                }
                 continue;
             }
             airdrop.update(dt);

--- a/server/src/game/objects/airdrop.ts
+++ b/server/src/game/objects/airdrop.ts
@@ -24,24 +24,15 @@ export class AirdropBarn {
     update(dt: number) {
         for (let i = 0; i < this.airdrops.length; i++) {
             const airdrop = this.airdrops[i];
-            if (airdrop.sentLandedToClients) {
+            airdrop.update(dt);
+
+            if (airdrop.landed) {
                 airdrop.fallTime -= dt;
                 if (airdrop.fallTime <= -1.0) {
                     this.airdrops.splice(i, 1);
                     i--;
                     airdrop.destroy();
                 }
-                continue;
-            }
-            airdrop.update(dt);
-        }
-    }
-
-    flush() {
-        for (let i = 0; i < this.airdrops.length; i++) {
-            const airdrop = this.airdrops[i];
-            if (airdrop.landed) {
-                airdrop.sentLandedToClients = true;
             }
         }
     }
@@ -56,7 +47,6 @@ export class Airdrop extends BaseGameObject {
     fallTime = GameConfig.airdrop.fallTime;
     fallT = 0;
     landed = false;
-    sentLandedToClients = false;
 
     obstacleType: string;
     crateCollision: Collider;


### PR DESCRIPTION
mentioned in https://discord.com/channels/1407084649343352852/1504105653176762389

issue:
when the client processes two `UpdateMsg`s, one where the airdrop is set to landed, and the next where the airdrop is deleted for having landed in one client frame, then the landing effects are never played