### PR TITLE
feat: tint loadout svgs with svg filter

### DIFF
--- a/client/src/helpers.ts
+++ b/client/src/helpers.ts
@@ -1,10 +1,10 @@
 import $ from "jquery";
 
 import type { MeleeDef } from "../../shared/defs/gameObjects/meleeDefs.ts";
-import type { OutfitDef } from "../../shared/defs/gameObjects/outfitDefs.ts";
 import { type MapDefKey, MapDefs } from "../../shared/defs/mapDefs.ts";
 import { GameObjectDefs } from "../../shared/defs/register.ts";
 import * as net from "../../shared/net/net.ts";
+import { util } from "../../shared/utils/util.ts";
 import { device } from "./device.ts";
 
 const truncateCanvas = document.createElement("canvas");
@@ -194,20 +194,7 @@ export const helpers = {
             case "crosshair":
                 return `img/crosshairs/${def.texture.slice(0, -4)}.svg`;
             case "outfit": {
-                const lootImg = (def as OutfitDef).lootImg;
-                if (lootImg.sprite !== "loot-shirt-01.img") {
-                    return `img/loot/${lootImg.sprite.slice(0, -4)}.svg`;
-                }
-
-                // tint outfits using loot-shirt-01
-                const outfitSvg =
-                    `<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128"><path d="M63.993 8.15c-10.38 0-22.796 3.526-30.355 7.22-8.038 3.266-14.581 7.287-19.253 14.509C8.102 39.594 5.051 54.6 7.13 78.482c5.964 2.07 11.333 1.45 16.842-.415-1.727-7.884-1.448-15.764.496-22.204 2.126-7.044 6.404-12.722 12.675-13.701l2.77-.432.074 2.803c.054 2.043.09 4.17.116 6.335l.027 6.312c-.037 8.798-.382 18.286-1.277 27.845 5.637 1.831 14.806 2.954 23.964 3.019l4.597-.058c8.53-.275 16.742-1.449 21.665-3.063-1.093-14.65-1.166-29.434-1.52-41.334l-.097-3.283 3.18.824c6.238 1.617 10.55 7.376 12.76 14.507 2.02 6.51 2.353 14.37.64 22.248a29.764 29.764 0 0 0 12.847 1.181l4.399-.588c1.033-18.811-1.433-37.403-6.27-46.264l-4.408-6.376c-4.647-5.357-10.62-8.399-17.665-11.074-6.746-3.458-18.358-6.614-28.95-6.614zm0 3.05c6.494 0 13.37 1.942 19.274 4.516-3.123 2.758-6.971 4.665-11.067 5.754l-7.852 17.31-6.838-16.882c-4.757-.93-9.26-2.957-12.783-6.174C50.9 13.081 57.809 11.2 63.993 11.2zm.58 28.539l3.512 5.327-3.497 5.053-3.53-5.053zm0 11.888l3.512 5.328-3.497 5.052-3.53-5.053 3.514-5.327zm0 11.733l3.512 5.327-3.497 5.054-3.53-5.054zm0 11.876l3.512 5.327-3.497 5.054-3.53-5.053 3.514-5.327zm25.079 13.715c-6.61 2.055-15.829 2.907-25.277 2.951-9.5.045-18.965-.744-25.902-2.892-.205 1.785-.43 3.569-.678 5.347 5.968 2.132 16.346 3.408 26.497 3.36 10.143-.05 20.355-1.444 25.912-3.433a241.302 241.302 0 0 1-.552-5.333zm1.368 9.086c-6.782 2.308-16.533 3.262-26.53 3.31-2.935.015-5.866-.052-8.724-.213l-4.227-.315c-5.358-.5-10.307-1.382-14.329-2.758-.897 5.43-2.02 10.772-3.413 15.903 2.117 1.06 4.41 1.968 6.835 2.733l3.97 1.096c15.85 3.805 35.88 2.156 49.601-3.513-1.355-5.09-2.387-10.57-3.183-16.243z" fill="${
-                        this.colorToHexString(lootImg.tint)
-                    }"/></svg>`;
-
-                return URL.createObjectURL(
-                    new Blob([outfitSvg], { type: "image/svg+xml;charset=utf-8" }),
-                );
+                return `img/loot/${def.lootImg.sprite.slice(0, -4)}.svg`;
             }
             default:
                 return "";
@@ -220,6 +207,44 @@ export const helpers = {
             transform = `rotate(${def.lootImg.rot || 0}rad) scaleX(${def.lootImg.mirror ? -1 : 1})`;
         }
         return transform;
+    },
+    getSvgFilterForTint(tint: number) {
+        if (tint === 0xffffff) return undefined;
+
+        const rgb = util.intToRgb(tint);
+        const r = rgb.r / 255;
+        const g = rgb.g / 255;
+        const b = rgb.b / 255;
+
+        const filterId = `svg-tint-${tint}`;
+
+        const filter = `<filter id="${filterId}" color-interpolation-filters="sRGB">\
+<feColorMatrix in="SourceGraphic" type="matrix" \
+values="\
+${r} 0 0 0 0 \
+0 ${g} 0 0 0 \
+0 0 ${b} 0 0 \
+0 0 0 1 0"/>\
+</filter>`;
+
+        // safari / webkit SUCKS and doesn't work with inline/or blob svg filters
+        // so we need to append the filter to the document...
+        if (navigator.userAgent.includes("AppleWebKit") && !navigator.userAgent.includes("Chrome")) {
+            if (!document.getElementById(filterId)) {
+                let svgRoot = document.getElementById("tint-filter-svg-root") as unknown as SVGSVGElement | undefined;
+                if (!svgRoot) {
+                    svgRoot = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+                    svgRoot.id = "tint-filter-svg-root";
+                    svgRoot.style.display = "none";
+                    document.body.append(svgRoot);
+                }
+                svgRoot.innerHTML += filter;
+            }
+            return `url(#${filterId})`;
+        }
+
+        const svg = encodeURI(`data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg">${filter}</svg>`);
+        return `url(${svg}#${filterId})`;
     },
     random64: function() {
         function r32() {

--- a/client/src/ui/loadoutMenu.ts
+++ b/client/src/ui/loadoutMenu.ts
@@ -4,6 +4,7 @@ import $ from "jquery";
 import type { GameObjectDef } from "../../../shared/defs/gameObjectDefs.ts";
 import { EmoteCategory, type EmoteDef } from "../../../shared/defs/gameObjects/emoteDefs.ts";
 import type { MeleeDef } from "../../../shared/defs/gameObjects/meleeDefs.ts";
+import type { OutfitDef } from "../../../shared/defs/gameObjects/outfitDefs.ts";
 import { GameObjectDefs } from "../../../shared/defs/register.ts";
 import { EmoteSlot, Rarity } from "../../../shared/gameConfig.ts";
 import type { PassState } from "../../../shared/types/user.ts";
@@ -977,7 +978,7 @@ export class LoadoutMenu {
         const listItems = $("<div/>");
         for (let i = 0; i < loadoutItems.length; i++) {
             const item = loadoutItems[i];
-            const objDef = GameObjectDefs.typeToDef(item.type) as MeleeDef;
+            const objDef = GameObjectDefs.typeToDef(item.type) as OutfitDef | MeleeDef;
 
             const itemInfo: ItemInfo = {
                 loadoutType: category.loadoutType,
@@ -1005,6 +1006,7 @@ export class LoadoutMenu {
                 css: {
                     "background-image": `url(${svg})`,
                     transform,
+                    filter: objDef.type === "outfit" ? helpers.getSvgFilterForTint(objDef.lootImg.tint) : undefined,
                 },
                 "data-img": `url(${svg})`,
                 draggable,


### PR DESCRIPTION
TODO: test if this works in bad browsers (aka safari)

This allows any outfit lootImg to be tinted in the loadout menu, removing the need for a lot of outfits to have their own custom `lootImg` svg

CC @SquaredHexahedron 

related: #476