### PR TITLE
perf(wip?): grid interest batching

### DIFF
--- a/server/bench/interestBenchmark.ts
+++ b/server/bench/interestBenchmark.ts
@@ -1,0 +1,361 @@
+import type { AABB } from "../../shared/utils/coldet.ts";
+import type { Vec2 } from "../../shared/utils/v2.ts";
+import { Grid } from "../src/game/grid.ts";
+import type { GridInterest } from "../src/game/gridInterest.ts";
+
+interface ReferenceObject {
+    __id: number;
+    __gridBounds: { min: Vec2; max: Vec2 };
+    __onGrid: boolean;
+    __gridQueryId: number;
+    bounds: AABB;
+    pos: Vec2;
+}
+
+interface MovingObject<T extends { pos: Vec2 }> {
+    object: T;
+    vx: number;
+    vy: number;
+}
+
+interface MovingClient {
+    view: AABB;
+    vx: number;
+    vy: number;
+}
+
+interface Scenario {
+    name: string;
+    movingObjects: number;
+    objectSpeed: number;
+    clientSpeed: number;
+}
+
+interface WorkResult {
+    visibleCount: number;
+    visibleIdSum: number;
+    addedIdSum: number;
+    removedIdSum: number;
+    objectCellChanges: number;
+    viewCellChanges: number;
+}
+
+interface TrialResult {
+    milliseconds: number;
+    work: WorkResult;
+}
+
+const worldSize = 1024;
+const objectCount = 2_400;
+const clientCount = 80;
+const maxClientCapacity = 256;
+const warmupFrames = 300;
+const measuredFrames = 1_200;
+const trialCount = 5;
+const objectBounds = aabb(-1, -1, 1, 1);
+
+const scenarios: Scenario[] = [
+    { name: "quiet", movingObjects: 80, objectSpeed: 0.5, clientSpeed: 0.35 },
+    { name: "typical", movingObjects: 240, objectSpeed: 1.5, clientSpeed: 1 },
+    { name: "busy", movingObjects: 800, objectSpeed: 5, clientSpeed: 3 },
+    { name: "pathological", movingObjects: 2_400, objectSpeed: 20, clientSpeed: 12 },
+];
+
+console.log(
+    `TypeScript interest benchmark: ${objectCount} objects, ${clientCount}/${maxClientCapacity} clients, `
+        + `${measuredFrames} measured frames, median of ${trialCount}`,
+);
+
+for (const scenario of scenarios) {
+    const referenceTrials: TrialResult[] = [];
+    const incrementalTrials: TrialResult[] = [];
+
+    for (let trial = 0; trial < trialCount; trial++) {
+        // Alternate order to reduce systematic JIT, thermal, and GC bias.
+        if (trial % 2 === 0) {
+            referenceTrials.push(runReference(scenario));
+            incrementalTrials.push(runIncremental(scenario));
+        } else {
+            incrementalTrials.push(runIncremental(scenario));
+            referenceTrials.push(runReference(scenario));
+        }
+    }
+
+    const reference = medianTrial(referenceTrials);
+    const incremental = medianTrial(incrementalTrials);
+    assertEquivalentWork(reference.work, incremental.work, scenario.name);
+    const speedup = reference.milliseconds / incremental.milliseconds;
+    const timeChange = (incremental.milliseconds / reference.milliseconds - 1) * 100;
+
+    console.log(`\n${scenario.name}`);
+    console.table([
+        {
+            backend: "Grid query + full diff",
+            milliseconds: reference.milliseconds.toFixed(1),
+            "frames/sec": (measuredFrames * 1000 / reference.milliseconds).toFixed(0),
+            speedup: "1.00x",
+            "time change": "baseline",
+        },
+        {
+            backend: "Integrated incremental grid",
+            milliseconds: incremental.milliseconds.toFixed(1),
+            "frames/sec": (measuredFrames * 1000 / incremental.milliseconds).toFixed(0),
+            speedup: `${speedup.toFixed(2)}x`,
+            "time change": `${timeChange >= 0 ? "+" : ""}${timeChange.toFixed(1)}%`,
+        },
+    ]);
+    console.log(
+        `rounded-cell changes: ${incremental.work.objectCellChanges.toLocaleString()} objects, `
+            + `${incremental.work.viewCellChanges.toLocaleString()} views`,
+    );
+}
+
+const productionMemory = new Grid<ReferenceObject>(worldSize, worldSize).enableInterest({
+    maxObjectId: 65_535,
+    maxClients: maxClientCapacity,
+}).memoryEstimate();
+console.log(
+    `\nProduction-capacity typed arrays: ${formatBytes(productionMemory.totalTypedArrayBytes)} `
+        + "(excludes JS object arrays and Set storage)",
+);
+
+function runReference(scenario: Scenario): TrialResult {
+    const random = mulberry32(0x1a2b3c4d);
+    const grid = new Grid<ReferenceObject>(worldSize, worldSize);
+    const objects = createObjects(random, scenario, true);
+    const clients = createClients(random, scenario);
+
+    for (const moving of objects) grid.addObject(moving.object);
+    const previous = clients.map(client => grid.intersectAABBSet(client.view));
+    for (let frame = 0; frame < warmupFrames; frame++) {
+        referenceFrame(grid, objects, clients, previous, scenario, false);
+    }
+
+    const start = performance.now();
+    let work = emptyWork();
+    for (let frame = 0; frame < measuredFrames; frame++) {
+        work = addWork(work, referenceFrame(grid, objects, clients, previous, scenario, true));
+    }
+    return { milliseconds: performance.now() - start, work };
+}
+
+function runIncremental(scenario: Scenario): TrialResult {
+    const random = mulberry32(0x1a2b3c4d);
+    const grid = new Grid<ReferenceObject>(worldSize, worldSize);
+    const index = grid.enableInterest({
+        maxObjectId: objectCount + 1,
+        maxClients: maxClientCapacity,
+    });
+    const objects = createObjects(random, scenario, true);
+    const clients = createClients(random, scenario);
+
+    for (const moving of objects) grid.addObject(moving.object);
+    for (let client = 0; client < clients.length; client++) {
+        index.updateClientView(client, clients[client].view);
+        index.drainChanges(client);
+    }
+    for (let frame = 0; frame < warmupFrames; frame++) {
+        incrementalFrame(grid, index, objects, clients, scenario, false);
+    }
+
+    const start = performance.now();
+    let work = emptyWork();
+    for (let frame = 0; frame < measuredFrames; frame++) {
+        work = addWork(work, incrementalFrame(grid, index, objects, clients, scenario, true));
+    }
+    return { milliseconds: performance.now() - start, work };
+}
+
+function referenceFrame(
+    grid: Grid<ReferenceObject>,
+    objects: Array<MovingObject<ReferenceObject>>,
+    clients: MovingClient[],
+    previous: Array<Set<ReferenceObject>>,
+    scenario: Scenario,
+    collect: boolean,
+): WorkResult {
+    for (let index = 0; index < scenario.movingObjects; index++) {
+        const moving = objects[index];
+        moveObject(moving, scenario.objectSpeed);
+        grid.updateObject(moving.object);
+    }
+
+    const work = emptyWork();
+    for (let clientSlot = 0; clientSlot < clients.length; clientSlot++) {
+        const client = clients[clientSlot];
+        moveView(client, scenario.clientSpeed);
+        const visible = grid.intersectAABBSet(client.view);
+        if (collect) {
+            for (const object of previous[clientSlot]) {
+                if (!visible.has(object)) work.removedIdSum += object.__id;
+            }
+            for (const object of visible) {
+                work.visibleCount++;
+                work.visibleIdSum += object.__id;
+                if (!previous[clientSlot].has(object)) work.addedIdSum += object.__id;
+            }
+        }
+        previous[clientSlot] = visible;
+    }
+    return work;
+}
+
+function incrementalFrame(
+    grid: Grid<ReferenceObject>,
+    index: GridInterest<ReferenceObject>,
+    objects: Array<MovingObject<ReferenceObject>>,
+    clients: MovingClient[],
+    scenario: Scenario,
+    collect: boolean,
+): WorkResult {
+    const work = emptyWork();
+    for (let objectIndex = 0; objectIndex < scenario.movingObjects; objectIndex++) {
+        const moving = objects[objectIndex];
+        moveObject(moving, scenario.objectSpeed);
+        if (grid.updateObject(moving.object) && collect) work.objectCellChanges++;
+    }
+
+    for (let clientSlot = 0; clientSlot < clients.length; clientSlot++) {
+        const client = clients[clientSlot];
+        moveView(client, scenario.clientSpeed);
+        if (index.updateClientView(clientSlot, client.view) && collect) work.viewCellChanges++;
+        index.consumeChanges(clientSlot, snapshot => {
+            if (!collect) return;
+            for (const object of snapshot.removed) work.removedIdSum += object.__id;
+            for (const object of snapshot.visible) {
+                work.visibleCount++;
+                work.visibleIdSum += object.__id;
+                if (snapshot.added.has(object)) work.addedIdSum += object.__id;
+            }
+        });
+    }
+    return work;
+}
+
+function createObjects(
+    random: () => number,
+    scenario: Scenario,
+    _reference: boolean,
+): Array<MovingObject<ReferenceObject>> {
+    const objects: Array<MovingObject<ReferenceObject>> = [];
+    for (let id = 1; id <= objectCount; id++) {
+        const object: ReferenceObject = {
+            __id: id,
+            __gridBounds: { min: { x: -1, y: -1 }, max: { x: -1, y: -1 } },
+            __onGrid: false,
+            __gridQueryId: 0,
+            bounds: objectBounds,
+            pos: randomWorldPosition(random),
+        };
+        const angle = random() * Math.PI * 2;
+        objects.push({ object, vx: Math.cos(angle), vy: Math.sin(angle) });
+    }
+    // Consume the scenario argument in both implementations to make accidental setup drift obvious.
+    if (scenario.movingObjects > objects.length) throw new Error("Too many moving objects");
+    return objects;
+}
+
+function createClients(random: () => number, scenario: Scenario): MovingClient[] {
+    const clients: MovingClient[] = [];
+    for (let index = 0; index < clientCount; index++) {
+        const center = randomWorldPosition(random);
+        const angle = random() * Math.PI * 2;
+        clients.push({
+            view: aabb(center.x - 64, center.y - 36, center.x + 64, center.y + 36),
+            vx: Math.cos(angle),
+            vy: Math.sin(angle),
+        });
+    }
+    if (scenario.clientSpeed < 0) throw new Error("Client speed cannot be negative");
+    return clients;
+}
+
+function moveObject<T extends { pos: Vec2 }>(moving: MovingObject<T>, speed: number): void {
+    const position = moving.object.pos;
+    position.x += moving.vx * speed;
+    position.y += moving.vy * speed;
+    if (position.x < 0 || position.x > worldSize) {
+        moving.vx *= -1;
+        position.x = Math.max(0, Math.min(worldSize, position.x));
+    }
+    if (position.y < 0 || position.y > worldSize) {
+        moving.vy *= -1;
+        position.y = Math.max(0, Math.min(worldSize, position.y));
+    }
+}
+
+function moveView(client: MovingClient, speed: number): void {
+    client.view.min.x += client.vx * speed;
+    client.view.max.x += client.vx * speed;
+    client.view.min.y += client.vy * speed;
+    client.view.max.y += client.vy * speed;
+    if (client.view.min.x < 0 || client.view.max.x > worldSize) {
+        client.vx *= -1;
+        const correction = client.view.min.x < 0 ? -client.view.min.x : worldSize - client.view.max.x;
+        client.view.min.x += correction;
+        client.view.max.x += correction;
+    }
+    if (client.view.min.y < 0 || client.view.max.y > worldSize) {
+        client.vy *= -1;
+        const correction = client.view.min.y < 0 ? -client.view.min.y : worldSize - client.view.max.y;
+        client.view.min.y += correction;
+        client.view.max.y += correction;
+    }
+}
+
+function emptyWork(): WorkResult {
+    return {
+        visibleCount: 0,
+        visibleIdSum: 0,
+        addedIdSum: 0,
+        removedIdSum: 0,
+        objectCellChanges: 0,
+        viewCellChanges: 0,
+    };
+}
+
+function addWork(total: WorkResult, frame: WorkResult): WorkResult {
+    total.visibleCount += frame.visibleCount;
+    total.visibleIdSum += frame.visibleIdSum;
+    total.addedIdSum += frame.addedIdSum;
+    total.removedIdSum += frame.removedIdSum;
+    total.objectCellChanges += frame.objectCellChanges;
+    total.viewCellChanges += frame.viewCellChanges;
+    return total;
+}
+
+function assertEquivalentWork(reference: WorkResult, incremental: WorkResult, scenario: string): void {
+    for (const field of ["visibleCount", "visibleIdSum", "addedIdSum", "removedIdSum"] as const) {
+        if (reference[field] !== incremental[field]) {
+            throw new Error(
+                `${scenario}: ${field} differs: Grid=${reference[field]}, incremental=${incremental[field]}`,
+            );
+        }
+    }
+}
+
+function medianTrial(trials: TrialResult[]): TrialResult {
+    return [...trials].sort((a, b) => a.milliseconds - b.milliseconds)[Math.floor(trials.length / 2)];
+}
+
+function randomWorldPosition(random: () => number): Vec2 {
+    return { x: random() * worldSize, y: random() * worldSize };
+}
+
+function aabb(minX: number, minY: number, maxX: number, maxY: number): AABB {
+    return { type: 1, min: { x: minX, y: minY }, max: { x: maxX, y: maxY } };
+}
+
+function formatBytes(bytes: number): string {
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+function mulberry32(seed: number): () => number {
+    return () => {
+        seed |= 0;
+        seed = seed + 0x6d2b79f5 | 0;
+        let value = Math.imul(seed ^ seed >>> 15, 1 | seed);
+        value = value + Math.imul(value ^ value >>> 7, 61 | value) ^ value;
+        return ((value ^ value >>> 14) >>> 0) / 4294967296;
+    };
+}

--- a/server/bench/interestBenchmark.ts
+++ b/server/bench/interestBenchmark.ts
@@ -214,6 +214,7 @@ function incrementalFrame(
         moveObject(moving, scenario.objectSpeed);
         if (grid.updateObject(moving.object) && collect) work.objectCellChanges++;
     }
+    index.flushObjectUpdates();
 
     for (let clientSlot = 0; clientSlot < clients.length; clientSlot++) {
         const client = clients[clientSlot];

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "dev": "concurrently \"pnpm run dev:api\" \"pnpm run dev:game\"",
     "dev:api": "tsx watch --clear-screen=false --include ../survev-config.hjson src/api/index.ts",
     "dev:game": "tsx watch --clear-screen=false --include ../survev-config.hjson --include ./src/game --include ../shared src/gameServer.ts",
+    "bench:interest": "tsx bench/interestBenchmark.ts",
     "db:generate": "drizzle-kit generate --config=src/api/drizzle.config.ts",
     "db:migrate": "drizzle-kit migrate --config=src/api/drizzle.config.ts",
     "db:seed": "tsx src/api/db/seed.ts",

--- a/server/src/game/client.ts
+++ b/server/src/game/client.ts
@@ -21,6 +21,8 @@ import type { ClientSocket } from "./socket.ts";
 
 export class ClientBarn {
     clients: Client[] = [];
+    private readonly freeInterestSlots: number[] = [];
+    private nextInterestSlot = 0;
 
     /**
      * All msgs created this tick that will be sent to all players
@@ -51,6 +53,20 @@ export class ClientBarn {
         this.msgsToSend.stream.index = 0;
     }
 
+    allocateInterestSlot(): number | undefined {
+        const reused = this.freeInterestSlots.pop();
+        if (reused !== undefined) return reused;
+        if (this.nextInterestSlot >= this.game.gridInterest.maxClients) return undefined;
+        return this.nextInterestSlot++;
+    }
+
+    releaseInterestSlot(client: Client): void {
+        if (client.interestSlot < 0) return;
+        this.game.gridInterest.removeClient(client.interestSlot);
+        this.freeInterestSlots.push(client.interestSlot);
+        client.interestSlot = -1;
+    }
+
     addClientWithPlayer(socket: ClientSocket<Client>, joinData: JoinTokenData, joinMsg: net.JoinMsg) {
         if (Config.rateLimitsEnabled) {
             const count = this.clients.filter(
@@ -66,7 +82,18 @@ export class ClientBarn {
             }
         }
 
-        const client = new Client(this.game, socket, joinData.userId, joinData.findGameIp);
+        const interestSlot = this.allocateInterestSlot();
+        if (interestSlot === undefined) {
+            socket.close("full");
+            return;
+        }
+        const client = new Client(
+            this.game,
+            socket,
+            joinData.userId,
+            joinData.findGameIp,
+            interestSlot,
+        );
         this.clients.push(client);
 
         const player = this.game.playerBarn.addPlayer(client, joinMsg, joinData);
@@ -83,7 +110,12 @@ export class ClientBarn {
             return;
         }
 
-        const client = new Client(this.game, socket, null, "");
+        const interestSlot = this.allocateInterestSlot();
+        if (interestSlot === undefined) {
+            socket.close("full");
+            return;
+        }
+        const client = new Client(this.game, socket, null, "", interestSlot);
         this.clients.push(client);
 
         client.specAnon = specData.specAnon;
@@ -246,8 +278,10 @@ export class ClientBarn {
     handleSocketClose(socket: ClientSocket<Client>) {
         const client = socket.getUserData();
         if (!client) return;
+        if (client.disconnected) return;
         client.spectating = undefined;
         client.disconnected = true;
+        this.releaseInterestSlot(client);
         util.removeFrom(this.clients, client);
 
         if (!client.player) return;
@@ -331,7 +365,7 @@ export class Client {
     spectateNewPlayerTicker = 0;
 
     private _firstUpdate = true;
-    visibleObjects = new Set<GameObject>();
+    visibleObjects: ReadonlySet<GameObject> = new Set();
     visibleMapIndicators = new Set<MapIndicator>();
 
     // zoom used for the area in which the server will send objects to the client
@@ -351,6 +385,7 @@ export class Client {
         socket: ClientSocket<Client>,
         userId: string | null,
         findGameIp: string,
+        public interestSlot: number,
     ) {
         this.userId = userId;
         this.ip = socket.ip();
@@ -494,29 +529,27 @@ export class Client {
         }
         const rect = collider.createAabbExtents(player.pos, v2.create(width, height));
 
-        const newVisibleObjects = game.grid.intersectAABBSet(rect);
-        // client crashes if active player is not visible
-        // so make sure its always added to visible objects
-        newVisibleObjects.add(player);
-
-        for (const obj of this.visibleObjects) {
-            if (!newVisibleObjects.has(obj)) {
+        game.gridInterest.updateClientView(this.interestSlot, rect);
+        // The client crashes if its active player is not visible, so preserve the old forced insert.
+        game.gridInterest.setForcedObject(this.interestSlot, player);
+        game.gridInterest.consumeChanges(this.interestSlot, snapshot => {
+            for (const obj of snapshot.removed) {
                 updateMsg.delObjIds.push(obj.__id);
             }
-        }
 
-        for (const obj of newVisibleObjects) {
-            if (
-                !this.visibleObjects.has(obj)
-                || game.objectRegister.dirtyFull[obj.__id]
-            ) {
-                updateMsg.fullObjects.push(obj);
-            } else if (game.objectRegister.dirtyPart[obj.__id]) {
-                updateMsg.partObjects.push(obj);
+            for (const obj of snapshot.visible) {
+                if (
+                    snapshot.added.has(obj)
+                    || game.objectRegister.dirtyFull[obj.__id]
+                ) {
+                    updateMsg.fullObjects.push(obj);
+                } else if (game.objectRegister.dirtyPart[obj.__id]) {
+                    updateMsg.partObjects.push(obj);
+                }
             }
-        }
 
-        this.visibleObjects = newVisibleObjects;
+            this.visibleObjects = snapshot.visible;
+        });
 
         updateMsg.activePlayerId = player.__id;
         if (this.startedSpectating) {

--- a/server/src/game/client.ts
+++ b/server/src/game/client.ts
@@ -6,7 +6,7 @@ import { ObjectType } from "../../../shared/net/objectSerializeFns.ts";
 import { SpectateAction } from "../../../shared/net/spectateMsg.ts";
 import type { Emote, GroupStatus } from "../../../shared/net/updateMsg.ts";
 import type { GameWsDisconnectReason } from "../../../shared/types/api.ts";
-import { coldet } from "../../../shared/utils/coldet.ts";
+import { type AABB, coldet } from "../../../shared/utils/coldet.ts";
 import { collider } from "../../../shared/utils/collider.ts";
 import { math } from "../../../shared/utils/math.ts";
 import { util } from "../../../shared/utils/util.ts";
@@ -22,6 +22,8 @@ import type { ClientSocket } from "./socket.ts";
 export class ClientBarn {
     clients: Client[] = [];
     private readonly freeInterestSlots: number[] = [];
+    private readonly clientsByInterestSlot: Array<Client | undefined> = [];
+    private readonly preparedClients: Client[] = [];
     private nextInterestSlot = 0;
 
     /**
@@ -41,10 +43,39 @@ export class ClientBarn {
         }
     }
 
-    sendMsgs() {
+    prepareMsgs() {
+        this.preparedClients.length = 0;
         for (let i = 0; i < this.clients.length; i++) {
             const client = this.clients[i];
             if (client.socket.closed()) continue;
+            if (client.prepareMsg()) this.preparedClients.push(client);
+        }
+    }
+
+    routeDirtyObjects() {
+        const register = this.game.objectRegister;
+        register.forEachDirtyObject((object, full) => {
+            this.game.gridInterest.forEachSpatialClient(object, clientSlot => {
+                this.clientsByInterestSlot[clientSlot]?.routeDirtyObject(object, full);
+            });
+        });
+
+        // Forced visibility is intentionally separate from the spatial object mask.
+        for (let i = 0; i < this.preparedClients.length; i++) {
+            const client = this.preparedClients[i];
+            const forced = client.preparedPlayer;
+            if (
+                register.isDirty(forced)
+                && !this.game.gridInterest.isSpatiallyVisible(forced, client.interestSlot)
+            ) {
+                client.routeDirtyObject(forced, register.isFullDirty(forced));
+            }
+        }
+    }
+
+    sendMsgs() {
+        for (let i = 0; i < this.preparedClients.length; i++) {
+            const client = this.preparedClients[i];
             client.sendMsgs();
         }
     }
@@ -60,9 +91,14 @@ export class ClientBarn {
         return this.nextInterestSlot++;
     }
 
+    registerInterestClient(client: Client): void {
+        this.clientsByInterestSlot[client.interestSlot] = client;
+    }
+
     releaseInterestSlot(client: Client): void {
         if (client.interestSlot < 0) return;
         this.game.gridInterest.removeClient(client.interestSlot);
+        this.clientsByInterestSlot[client.interestSlot] = undefined;
         this.freeInterestSlots.push(client.interestSlot);
         client.interestSlot = -1;
     }
@@ -378,6 +414,13 @@ export class Client {
     msgStream = new net.MsgStream(new ArrayBuffer(65536));
     msgsToSend: Array<{ type: number; msg: net.Msg }> = [];
 
+    private msgPrepared = false;
+    private msgPlayer?: Player;
+    private msgRect?: AABB;
+    private msgRadius = 0;
+    private readonly routedFullObjects: GameObject[] = [];
+    private readonly routedPartObjects: GameObject[] = [];
+
     ack = 0;
 
     constructor(
@@ -393,6 +436,7 @@ export class Client {
         this.game = game;
         socket.setUserData(this);
         this.socket = socket as ClientSocket<Client>;
+        game.clientBarn.registerInterestClient(this);
     }
 
     sendMsg(type: net.MsgType, msg: net.AbstractMsg): void {
@@ -474,14 +518,59 @@ export class Client {
         }
     }
 
+    get preparedPlayer(): Player {
+        if (!this.msgPrepared || !this.msgPlayer) {
+            throw new Error("Client message routing used before preparation");
+        }
+        return this.msgPlayer;
+    }
+
+    prepareMsg(): boolean {
+        this.msgPrepared = false;
+        this.routedFullObjects.length = 0;
+        this.routedPartObjects.length = 0;
+
+        const player = this.spectating ?? this.player;
+        if (!player) return false;
+
+        const radius = this._cullingZoom + 4;
+        let width = radius;
+        // client zoom tries to keep a 16/9 aspect ratio, mirror it here
+        let height = width / (16 / 9);
+        if (this._cullingPortrait) {
+            const tmp = width;
+            width = height;
+            height = tmp;
+        }
+        const rect = collider.createAabbExtents(player.pos, v2.create(width, height));
+
+        this.game.gridInterest.updateClientView(this.interestSlot, rect);
+        // The client crashes if its active player is not visible, so preserve the old forced insert.
+        this.game.gridInterest.setForcedObject(this.interestSlot, player);
+
+        this.msgPlayer = player;
+        this.msgRect = rect;
+        this.msgRadius = radius;
+        this.msgPrepared = true;
+        return true;
+    }
+
+    routeDirtyObject(object: GameObject, full: boolean): void {
+        if (!this.msgPrepared) return;
+        if (full) this.routedFullObjects.push(object);
+        else this.routedPartObjects.push(object);
+    }
+
     sendMsgs(): void {
         const msgStream = this.msgStream;
         const game = this.game;
         const playerBarn = game.playerBarn;
         msgStream.stream.index = 0;
 
-        const player = this.spectating ?? this.player;
-        if (!player) return;
+        if (!this.msgPrepared || !this.msgPlayer || !this.msgRect) return;
+        const player = this.msgPlayer;
+        const rect = this.msgRect;
+        const radius = this.msgRadius;
 
         if (this._firstUpdate) {
             const joinedMsg = new net.JoinedMsg();
@@ -518,34 +607,32 @@ export class Client {
             updateMsg.gasT = game.gas.gasT;
         }
 
-        const radius = this._cullingZoom + 4;
-        let width = this._cullingZoom + 4;
-        // client zoom tries to keep a 16/9 aspect ratio, mirror it here
-        let height = width / (16 / 9);
-        if (this._cullingPortrait) {
-            let tmp = width;
-            width = height;
-            height = tmp;
-        }
-        const rect = collider.createAabbExtents(player.pos, v2.create(width, height));
-
-        game.gridInterest.updateClientView(this.interestSlot, rect);
-        // The client crashes if its active player is not visible, so preserve the old forced insert.
-        game.gridInterest.setForcedObject(this.interestSlot, player);
         game.gridInterest.consumeChanges(this.interestSlot, snapshot => {
             for (const obj of snapshot.removed) {
                 updateMsg.delObjIds.push(obj.__id);
             }
 
-            for (const obj of snapshot.visible) {
-                if (
-                    snapshot.added.has(obj)
-                    || game.objectRegister.dirtyFull[obj.__id]
-                ) {
-                    updateMsg.fullObjects.push(obj);
-                } else if (game.objectRegister.dirtyPart[obj.__id]) {
-                    updateMsg.partObjects.push(obj);
-                }
+            for (const obj of snapshot.added) {
+                updateMsg.fullObjects.push(obj);
+            }
+            for (let i = 0; i < this.routedFullObjects.length; i++) {
+                const obj = this.routedFullObjects[i];
+                if (!snapshot.added.has(obj)) updateMsg.fullObjects.push(obj);
+            }
+            for (let i = 0; i < this.routedPartObjects.length; i++) {
+                const obj = this.routedPartObjects[i];
+                if (!snapshot.added.has(obj)) updateMsg.partObjects.push(obj);
+            }
+
+            const visibilityOrder = (first: GameObject, second: GameObject) => {
+                return game.gridInterest.visibilityOrder(this.interestSlot, first)
+                    - game.gridInterest.visibilityOrder(this.interestSlot, second);
+            };
+            if (updateMsg.fullObjects.length > 1) {
+                (updateMsg.fullObjects as GameObject[]).sort(visibilityOrder);
+            }
+            if (updateMsg.partObjects.length > 1) {
+                (updateMsg.partObjects as GameObject[]).sort(visibilityOrder);
             }
 
             this.visibleObjects = snapshot.visible;
@@ -741,6 +828,7 @@ export class Client {
 
         this.sendData(msgStream.getBuffer());
         this._firstUpdate = false;
+        this.msgPrepared = false;
     }
 
     handleMsg(type: net.MsgType, msg: net.Msg) {

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -309,6 +309,9 @@ export class Game {
 
         const start = performance.now();
 
+        // Interest is consumed only by network messages, so coalesce movement to final positions.
+        this.gridInterest.flushObjectUpdates();
+
         // serialize objects and send msgs
         this.objectRegister.serializeObjs();
         this.clientBarn.sendMsgs();

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -8,6 +8,7 @@ import { type FindGamePrivateBody, type ServerGameConfig } from "../utils/types.
 import { ClientBarn } from "./client.ts";
 import { GameModeManager } from "./gameModeManager.ts";
 import { Grid } from "./grid.ts";
+import type { GridInterest } from "./gridInterest.ts";
 import { GameMap } from "./map.ts";
 import { AirdropBarn } from "./objects/airdrop.ts";
 import { BulletBarn } from "./objects/bullet.ts";
@@ -88,6 +89,7 @@ export class Game {
     }
 
     grid: Grid<GameObject>;
+    gridInterest: GridInterest<GameObject>;
     map: GameMap;
     gas: Gas;
     objectRegister: ObjectRegister;
@@ -125,6 +127,7 @@ export class Game {
 
         this.map = new GameMap(this);
         this.grid = new Grid(this.map.width, this.map.height);
+        this.gridInterest = this.grid.enableInterest({ maxClients: 256 });
         this.objectRegister = new ObjectRegister(this.grid);
 
         this.clientBarn = new ClientBarn(this);

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -313,7 +313,9 @@ export class Game {
         this.gridInterest.flushObjectUpdates();
 
         // serialize objects and send msgs
+        this.clientBarn.prepareMsgs();
         this.objectRegister.serializeObjs();
+        this.clientBarn.routeDirtyObjects();
         this.clientBarn.sendMsgs();
 
         //

--- a/server/src/game/grid.ts
+++ b/server/src/game/grid.ts
@@ -76,12 +76,7 @@ export class Grid<T extends GameObject = GameObject> {
             && objBounds.max.y === max.y
         ) {
             if (newlyTracked) {
-                this._interest!.updateObject(obj, {
-                    minX: min.x,
-                    minY: min.y,
-                    maxX: max.x,
-                    maxY: max.y,
-                });
+                this._interest!.updateObject(obj);
             }
             return false;
         }
@@ -105,12 +100,7 @@ export class Grid<T extends GameObject = GameObject> {
         v2.set(objBounds.min, min);
         v2.set(objBounds.max, max);
         obj.__onGrid = true;
-        this._interest?.updateObject(obj, {
-            minX: min.x,
-            minY: min.y,
-            maxX: max.x,
-            maxY: max.y,
-        });
+        this._interest?.updateObject(obj);
         return true;
     }
 

--- a/server/src/game/grid.ts
+++ b/server/src/game/grid.ts
@@ -2,6 +2,7 @@ import type { AABB, Collider } from "../../../shared/utils/coldet.ts";
 import { collider } from "../../../shared/utils/collider.ts";
 import { math } from "../../../shared/utils/math.ts";
 import { v2, type Vec2 } from "../../../shared/utils/v2.ts";
+import { GridInterest, type GridInterestOptions } from "./gridInterest.ts";
 import type { Loot } from "./objects/loot.ts";
 
 interface GameObject {
@@ -23,6 +24,7 @@ export class Grid<T extends GameObject = GameObject> {
     //                        X     Y     Object
     //                      __^__ __^__   __^__
     private readonly _grid: Array<Array<Set<T>>>;
+    private _interest?: GridInterest<T>;
 
     private nextQueryId = 1;
 
@@ -40,10 +42,27 @@ export class Grid<T extends GameObject = GameObject> {
         this.updateObject(obj);
     }
 
+    /** Enables persistent client visibility tracking on this grid. */
+    enableInterest(options: GridInterestOptions<T> = {}): GridInterest<T> {
+        if (this._interest) return this._interest;
+        this._interest = new GridInterest<T>(this.width, this.height, this.cellSize, {
+            ...options,
+            objectsAt: (x, y) => this._grid[x][y],
+            objectBounds: object => ({
+                minX: object.__gridBounds.min.x,
+                minY: object.__gridBounds.min.y,
+                maxX: object.__gridBounds.max.x,
+                maxY: object.__gridBounds.max.y,
+            }),
+        });
+        return this._interest;
+    }
+
     /**
      * Add an object to the grid system
      */
-    updateObject(obj: T): void {
+    updateObject(obj: T): boolean {
+        const newlyTracked = this._interest?.prepareObject(obj) ?? false;
         const objBounds = obj.__gridBounds;
 
         const aabb = obj.bounds;
@@ -56,10 +75,25 @@ export class Grid<T extends GameObject = GameObject> {
             objBounds.min.x === min.x && objBounds.min.y === min.y && objBounds.max.x === max.x
             && objBounds.max.y === max.y
         ) {
-            return;
+            if (newlyTracked) {
+                this._interest!.updateObject(obj, {
+                    minX: min.x,
+                    minY: min.y,
+                    maxX: max.x,
+                    maxY: max.y,
+                });
+            }
+            return false;
         }
 
-        this.remove(obj);
+        if (obj.__onGrid) {
+            for (let x = objBounds.min.x; x <= objBounds.max.x; x++) {
+                const xRow = this._grid[x];
+                for (let y = objBounds.min.y; y <= objBounds.max.y; y++) {
+                    xRow[y].delete(obj);
+                }
+            }
+        }
 
         // Add it to all grid cells that it intersects
         for (let x = min.x; x <= max.x; x++) {
@@ -71,6 +105,13 @@ export class Grid<T extends GameObject = GameObject> {
         v2.set(objBounds.min, min);
         v2.set(objBounds.max, max);
         obj.__onGrid = true;
+        this._interest?.updateObject(obj, {
+            minX: min.x,
+            minY: min.y,
+            maxX: max.x,
+            maxY: max.y,
+        });
+        return true;
     }
 
     /**
@@ -78,6 +119,7 @@ export class Grid<T extends GameObject = GameObject> {
      */
     remove(obj: T): void {
         if (!obj.__onGrid) return;
+        this._interest?.prepareObject(obj);
 
         const { min, max } = obj.__gridBounds;
         for (let x = min.x; x <= max.x; x++) {
@@ -86,6 +128,7 @@ export class Grid<T extends GameObject = GameObject> {
                 xRow[y].delete(obj);
             }
         }
+        this._interest?.removeObject(obj);
         v2.set(min, v2.create(-1, -1));
         v2.set(max, v2.create(-1, -1));
         obj.__onGrid = false;

--- a/server/src/game/gridInterest.ts
+++ b/server/src/game/gridInterest.ts
@@ -62,6 +62,8 @@ export class GridInterest<T> {
     private readonly recomputeScratch: Uint32Array;
     private readonly objects: Array<T | undefined>;
     private readonly clients: Array<ClientState<T> | undefined>;
+    private readonly pendingObjectFlags: Uint8Array;
+    private readonly pendingObjectIds: number[] = [];
     private readonly affectedStamps: Uint32Array;
     private readonly affectedObjects: T[] = [];
     private readonly getObjectId: (object: T) => number;
@@ -95,6 +97,7 @@ export class GridInterest<T> {
         this.recomputeScratch = new Uint32Array(this.clientWordCount);
         this.objects = new Array(this.maxObjectId);
         this.clients = new Array(this.maxClients);
+        this.pendingObjectFlags = new Uint8Array(this.maxObjectId);
         this.affectedStamps = new Uint32Array(this.maxObjectId);
     }
 
@@ -116,10 +119,24 @@ export class GridInterest<T> {
         return true;
     }
 
-    updateObject(object: T, bounds: GridCellBounds): void {
-        if (this.rememberObject(object) === undefined) return;
+    updateObject(object: T): void {
+        const id = this.rememberObject(object);
+        if (id === undefined) return;
         if (this.activeClientCount === 0) return;
-        this.recomputeObjectClientMask(object, bounds);
+        if (this.pendingObjectFlags[id]) return;
+        this.pendingObjectFlags[id] = 1;
+        this.pendingObjectIds.push(id);
+    }
+
+    /** Resolves movement once at the network-sync boundary using each object's final grid bounds. */
+    flushObjectUpdates(): void {
+        for (let index = 0; index < this.pendingObjectIds.length; index++) {
+            const id = this.pendingObjectIds[index];
+            this.pendingObjectFlags[id] = 0;
+            const object = this.objects[id];
+            if (object) this.recomputeObjectClientMask(object, this.objectBounds(object));
+        }
+        this.pendingObjectIds.length = 0;
     }
 
     removeObject(object: T): void {
@@ -134,6 +151,8 @@ export class GridInterest<T> {
     }
 
     updateClientView(clientSlot: number, aabb: AABB): boolean {
+        // Subscriber masks must only change against fully resolved object positions.
+        this.flushObjectUpdates();
         clientSlot = this.validateClientSlot(clientSlot);
         const newBounds = this.aabbBounds(aabb);
         let client = this.clients[clientSlot];
@@ -178,6 +197,8 @@ export class GridInterest<T> {
     }
 
     removeClient(clientSlot: number): boolean {
+        // A disconnect can happen between network syncs; resolve movement before clearing its bit.
+        this.flushObjectUpdates();
         clientSlot = this.validateClientSlot(clientSlot);
         const client = this.clients[clientSlot];
         if (!client) return false;

--- a/server/src/game/gridInterest.ts
+++ b/server/src/game/gridInterest.ts
@@ -12,6 +12,8 @@ interface ClientState<T> {
     bounds?: GridCellBounds;
     forced?: T;
     visible: Set<T>;
+    visibleOrder: Map<T, number>;
+    nextVisibleOrder: number;
     added: Set<T>;
     removed: Set<T>;
 }
@@ -50,7 +52,8 @@ export interface InterestMemoryEstimate {
  * Persistent client visibility derived from an existing Grid's cells.
  *
  * Grid owns object membership and bounds. This tracker stores only cell subscribers, each object's
- * client mask, and per-client visible/change sets. Ordering is intentionally not part of its contract.
+ * client mask, and per-client visible/change sets. Visibility order follows Set insertion order so
+ * callers can reproduce the existing network object order without scanning the visible set.
  */
 export class GridInterest<T> {
     readonly maxObjectId: number;
@@ -157,7 +160,13 @@ export class GridInterest<T> {
         const newBounds = this.aabbBounds(aabb);
         let client = this.clients[clientSlot];
         if (!client) {
-            client = { visible: new Set(), added: new Set(), removed: new Set() };
+            client = {
+                visible: new Set(),
+                visibleOrder: new Map(),
+                nextVisibleOrder: 0,
+                added: new Set(),
+                removed: new Set(),
+            };
             this.clients[clientSlot] = client;
             this.activeClientCount++;
             this.highestActiveClientSlot = Math.max(this.highestActiveClientSlot, clientSlot);
@@ -226,6 +235,36 @@ export class GridInterest<T> {
 
     visibleObjects(clientSlot: number): ReadonlySet<T> {
         return this.client(clientSlot).visible;
+    }
+
+    /** Iterates clients that can see an object spatially. Forced visibility is handled separately. */
+    forEachSpatialClient(object: T, consumer: (clientSlot: number) => void): void {
+        const id = this.registeredObjectId(object);
+        if (id === undefined) return;
+        const objectMaskOffset = id * this.clientWordCount;
+        for (let word = 0; word < this.activeWordCount; word++) {
+            let clients = this.objectClientMasks[objectMaskOffset + word] >>> 0;
+            while (clients !== 0) {
+                const lowestBit = (clients & -clients) >>> 0;
+                const bit = 31 - Math.clz32(lowestBit);
+                const clientSlot = word * 32 + bit;
+                if (this.clients[clientSlot]) consumer(clientSlot);
+                clients = (clients & (clients - 1)) >>> 0;
+            }
+        }
+    }
+
+    isSpatiallyVisible(object: T, clientSlot: number): boolean {
+        clientSlot = this.validateClientSlot(clientSlot);
+        const id = this.registeredObjectId(object);
+        if (id === undefined) return false;
+        const word = clientSlot >>> 5;
+        const bit = 1 << (clientSlot & 31);
+        return (this.objectClientMasks[id * this.clientWordCount + word] & bit) !== 0;
+    }
+
+    visibilityOrder(clientSlot: number, object: T): number {
+        return this.client(clientSlot).visibleOrder.get(object) ?? Number.MAX_SAFE_INTEGER;
     }
 
     drainChanges(clientSlot: number): InterestChanges<T> {
@@ -312,20 +351,14 @@ export class GridInterest<T> {
     private addVisibleObject(client: ClientState<T>, object: T): void {
         if (client.visible.has(object)) return;
         client.visible.add(object);
+        client.visibleOrder.set(object, client.nextVisibleOrder++);
         if (!client.removed.delete(object)) client.added.add(object);
     }
 
     private removeVisibleObject(client: ClientState<T>, object: T): void {
         if (!client.visible.delete(object)) return;
+        client.visibleOrder.delete(object);
         if (!client.added.delete(object)) client.removed.add(object);
-    }
-
-    private isSpatiallyVisible(object: T, clientSlot: number): boolean {
-        const id = this.getObjectId(object);
-        if (!Number.isInteger(id) || id <= 0 || id >= this.maxObjectId) return false;
-        const word = clientSlot >>> 5;
-        const bit = 1 << (clientSlot & 31);
-        return (this.objectClientMasks[id * this.clientWordCount + word] & bit) !== 0;
     }
 
     private beginAffectedObjects(): void {

--- a/server/src/game/gridInterest.ts
+++ b/server/src/game/gridInterest.ts
@@ -1,0 +1,447 @@
+import type { AABB } from "../../../shared/utils/coldet.ts";
+import { math } from "../../../shared/utils/math.ts";
+
+export interface GridCellBounds {
+    minX: number;
+    minY: number;
+    maxX: number;
+    maxY: number;
+}
+
+interface ClientState<T> {
+    bounds?: GridCellBounds;
+    forced?: T;
+    visible: Set<T>;
+    added: Set<T>;
+    removed: Set<T>;
+}
+
+interface GridInterestHost<T> {
+    objectsAt: (x: number, y: number) => Iterable<T>;
+    objectBounds: (object: T) => GridCellBounds;
+}
+
+export interface GridInterestOptions<T> {
+    maxObjectId?: number;
+    maxClients?: number;
+    objectId?: (object: T) => number;
+}
+
+export interface InterestChanges<T> {
+    added: T[];
+    removed: T[];
+}
+
+export interface InterestSnapshot<T> {
+    visible: ReadonlySet<T>;
+    added: ReadonlySet<T>;
+    removed: ReadonlySet<T>;
+}
+
+export interface InterestMemoryEstimate {
+    cellSubscriberMasks: number;
+    objectClientMasks: number;
+    recomputeScratch: number;
+    affectedStamps: number;
+    totalTypedArrayBytes: number;
+}
+
+/**
+ * Persistent client visibility derived from an existing Grid's cells.
+ *
+ * Grid owns object membership and bounds. This tracker stores only cell subscribers, each object's
+ * client mask, and per-client visible/change sets. Ordering is intentionally not part of its contract.
+ */
+export class GridInterest<T> {
+    readonly maxObjectId: number;
+    readonly maxClients: number;
+    readonly clientWordCount: number;
+
+    private readonly cellSubscriberMasks: Uint32Array;
+    private readonly objectClientMasks: Uint32Array;
+    private readonly recomputeScratch: Uint32Array;
+    private readonly objects: Array<T | undefined>;
+    private readonly clients: Array<ClientState<T> | undefined>;
+    private readonly affectedStamps: Uint32Array;
+    private readonly affectedObjects: T[] = [];
+    private readonly getObjectId: (object: T) => number;
+    private affectedEpoch = 0;
+    private activeClientCount = 0;
+    private highestActiveClientSlot = -1;
+
+    constructor(
+        private readonly width: number,
+        private readonly height: number,
+        private readonly cellSize: number,
+        options: GridInterestOptions<T> & GridInterestHost<T>,
+    ) {
+        this.maxObjectId = options.maxObjectId ?? 65535;
+        this.maxClients = options.maxClients ?? 128;
+        this.clientWordCount = Math.ceil(this.maxClients / 32);
+        this.getObjectId = options.objectId ?? defaultObjectId;
+        this.objectsAt = options.objectsAt;
+        this.objectBounds = options.objectBounds;
+
+        if (!Number.isInteger(this.maxObjectId) || this.maxObjectId < 2) {
+            throw new RangeError("GridInterest maxObjectId must be an integer greater than one");
+        }
+        if (!Number.isInteger(this.maxClients) || this.maxClients < 1) {
+            throw new RangeError("GridInterest maxClients must be a positive integer");
+        }
+
+        const cellCount = (this.width + 1) * (this.height + 1);
+        this.cellSubscriberMasks = new Uint32Array(cellCount * this.clientWordCount);
+        this.objectClientMasks = new Uint32Array(this.maxObjectId * this.clientWordCount);
+        this.recomputeScratch = new Uint32Array(this.clientWordCount);
+        this.objects = new Array(this.maxObjectId);
+        this.clients = new Array(this.maxClients);
+        this.affectedStamps = new Uint32Array(this.maxObjectId);
+    }
+
+    private readonly objectsAt: GridInterestHost<T>["objectsAt"];
+    private readonly objectBounds: GridInterestHost<T>["objectBounds"];
+
+    /** Validates and reserves an object ID before Grid mutates cell membership. */
+    prepareObject(object: T): boolean {
+        const id = this.registeredObjectId(object);
+        if (id === undefined) return false;
+        const previousObject = this.objects[id];
+        if (previousObject && previousObject !== object) {
+            throw new Error(
+                `Grid interest object ID ${id} was reused before its previous object was removed`,
+            );
+        }
+        if (previousObject === object) return false;
+        this.objects[id] = object;
+        return true;
+    }
+
+    updateObject(object: T, bounds: GridCellBounds): void {
+        if (this.rememberObject(object) === undefined) return;
+        if (this.activeClientCount === 0) return;
+        this.recomputeObjectClientMask(object, bounds);
+    }
+
+    removeObject(object: T): void {
+        const id = this.registeredObjectId(object);
+        if (id === undefined) return;
+        const previousObject = this.objects[id];
+        if (previousObject && previousObject !== object) {
+            throw new Error(`Grid interest object ID ${id} belongs to another active object`);
+        }
+        if (previousObject) this.applyObjectClientMask(object, id, undefined);
+        this.objects[id] = undefined;
+    }
+
+    updateClientView(clientSlot: number, aabb: AABB): boolean {
+        clientSlot = this.validateClientSlot(clientSlot);
+        const newBounds = this.aabbBounds(aabb);
+        let client = this.clients[clientSlot];
+        if (!client) {
+            client = { visible: new Set(), added: new Set(), removed: new Set() };
+            this.clients[clientSlot] = client;
+            this.activeClientCount++;
+            this.highestActiveClientSlot = Math.max(this.highestActiveClientSlot, clientSlot);
+        }
+        const oldBounds = client.bounds;
+        if (oldBounds && boundsEqual(oldBounds, newBounds)) return false;
+
+        this.beginAffectedObjects();
+        if (oldBounds) {
+            this.forEachCellDifference(oldBounds, newBounds, (x, y, cellIndex) => {
+                this.setCellSubscriber(cellIndex, clientSlot, false);
+                this.markCellObjectsAffected(x, y);
+            });
+        }
+        this.forEachCellDifference(newBounds, oldBounds, (x, y, cellIndex) => {
+            this.setCellSubscriber(cellIndex, clientSlot, true);
+            this.markCellObjectsAffected(x, y);
+        });
+        client.bounds = newBounds;
+        this.recomputeAffectedObjects();
+        return true;
+    }
+
+    /** Keeps one object visible independently of spatial membership, for the active-player rule. */
+    setForcedObject(clientSlot: number, object: T | undefined): boolean {
+        clientSlot = this.validateClientSlot(clientSlot);
+        const client = this.client(clientSlot);
+        const previous = client.forced;
+        if (previous === object) return false;
+
+        client.forced = object;
+        if (previous && !this.isSpatiallyVisible(previous, clientSlot)) {
+            this.removeVisibleObject(client, previous);
+        }
+        if (object) this.addVisibleObject(client, object);
+        return true;
+    }
+
+    removeClient(clientSlot: number): boolean {
+        clientSlot = this.validateClientSlot(clientSlot);
+        const client = this.clients[clientSlot];
+        if (!client) return false;
+
+        this.beginAffectedObjects();
+        if (client.bounds) {
+            this.forEachCell(client.bounds, (x, y, cellIndex) => {
+                this.setCellSubscriber(cellIndex, clientSlot, false);
+                this.markCellObjectsAffected(x, y);
+            });
+        }
+        this.recomputeAffectedObjects();
+        this.clients[clientSlot] = undefined;
+        this.activeClientCount--;
+        if (clientSlot === this.highestActiveClientSlot) {
+            while (
+                this.highestActiveClientSlot >= 0
+                && !this.clients[this.highestActiveClientSlot]
+            ) {
+                this.highestActiveClientSlot--;
+            }
+        }
+        return true;
+    }
+
+    visibleObjects(clientSlot: number): ReadonlySet<T> {
+        return this.client(clientSlot).visible;
+    }
+
+    drainChanges(clientSlot: number): InterestChanges<T> {
+        const client = this.client(clientSlot);
+        const changes = { added: [...client.added], removed: [...client.removed] };
+        client.added.clear();
+        client.removed.clear();
+        return changes;
+    }
+
+    /** Reads persistent state without copies and clears changes after the callback. */
+    consumeChanges<Result>(
+        clientSlot: number,
+        consumer: (snapshot: InterestSnapshot<T>) => Result,
+    ): Result {
+        const client = this.client(clientSlot);
+        try {
+            return consumer(client);
+        } finally {
+            client.added.clear();
+            client.removed.clear();
+        }
+    }
+
+    memoryEstimate(): InterestMemoryEstimate {
+        const cellSubscriberMasks = this.cellSubscriberMasks.byteLength;
+        const objectClientMasks = this.objectClientMasks.byteLength;
+        const recomputeScratch = this.recomputeScratch.byteLength;
+        const affectedStamps = this.affectedStamps.byteLength;
+        return {
+            cellSubscriberMasks,
+            objectClientMasks,
+            recomputeScratch,
+            affectedStamps,
+            totalTypedArrayBytes: cellSubscriberMasks
+                + objectClientMasks
+                + recomputeScratch
+                + affectedStamps,
+        };
+    }
+
+    private recomputeObjectClientMask(object: T, bounds: GridCellBounds): void {
+        const id = this.rememberObject(object);
+        if (id === undefined) return;
+        const nextMask = this.recomputeScratch;
+        const activeWordCount = this.activeWordCount;
+        nextMask.fill(0, 0, activeWordCount);
+        this.forEachCell(bounds, (_x, _y, cellIndex) => {
+            const cellMaskOffset = cellIndex * this.clientWordCount;
+            for (let word = 0; word < activeWordCount; word++) {
+                nextMask[word] |= this.cellSubscriberMasks[cellMaskOffset + word];
+            }
+        });
+        this.applyObjectClientMask(object, id, nextMask);
+    }
+
+    private applyObjectClientMask(
+        object: T,
+        id: number,
+        nextMask: Uint32Array | undefined,
+    ): void {
+        const objectMaskOffset = id * this.clientWordCount;
+        for (let word = 0; word < this.activeWordCount; word++) {
+            const previous = this.objectClientMasks[objectMaskOffset + word];
+            const next = nextMask?.[word] ?? 0;
+            let changed = (previous ^ next) >>> 0;
+            while (changed !== 0) {
+                const lowestBit = (changed & -changed) >>> 0;
+                const bit = 31 - Math.clz32(lowestBit);
+                const client = this.clients[word * 32 + bit];
+                if (client) {
+                    if ((next & lowestBit) !== 0) {
+                        this.addVisibleObject(client, object);
+                    } else if (client.forced !== object) {
+                        this.removeVisibleObject(client, object);
+                    }
+                }
+                changed = (changed & (changed - 1)) >>> 0;
+            }
+            this.objectClientMasks[objectMaskOffset + word] = next;
+        }
+    }
+
+    private addVisibleObject(client: ClientState<T>, object: T): void {
+        if (client.visible.has(object)) return;
+        client.visible.add(object);
+        if (!client.removed.delete(object)) client.added.add(object);
+    }
+
+    private removeVisibleObject(client: ClientState<T>, object: T): void {
+        if (!client.visible.delete(object)) return;
+        if (!client.added.delete(object)) client.removed.add(object);
+    }
+
+    private isSpatiallyVisible(object: T, clientSlot: number): boolean {
+        const id = this.getObjectId(object);
+        if (!Number.isInteger(id) || id <= 0 || id >= this.maxObjectId) return false;
+        const word = clientSlot >>> 5;
+        const bit = 1 << (clientSlot & 31);
+        return (this.objectClientMasks[id * this.clientWordCount + word] & bit) !== 0;
+    }
+
+    private beginAffectedObjects(): void {
+        this.affectedObjects.length = 0;
+        this.affectedEpoch++;
+        if (this.affectedEpoch > 0xffffffff) {
+            this.affectedStamps.fill(0);
+            this.affectedEpoch = 1;
+        }
+    }
+
+    private markCellObjectsAffected(x: number, y: number): void {
+        for (const object of this.objectsAt(x, y)) {
+            const id = this.rememberObject(object);
+            if (id === undefined) continue;
+            if (this.affectedStamps[id] === this.affectedEpoch) continue;
+            this.affectedStamps[id] = this.affectedEpoch;
+            this.affectedObjects.push(object);
+        }
+    }
+
+    private recomputeAffectedObjects(): void {
+        for (let index = 0; index < this.affectedObjects.length; index++) {
+            const object = this.affectedObjects[index];
+            this.recomputeObjectClientMask(object, this.objectBounds(object));
+        }
+    }
+
+    private setCellSubscriber(cellIndex: number, clientSlot: number, subscribed: boolean): void {
+        const word = clientSlot >>> 5;
+        const bit = 1 << (clientSlot & 31);
+        const offset = cellIndex * this.clientWordCount + word;
+        if (subscribed) this.cellSubscriberMasks[offset] |= bit;
+        else this.cellSubscriberMasks[offset] &= ~bit;
+    }
+
+    private aabbBounds(aabb: AABB): GridCellBounds {
+        return {
+            minX: this.roundToCell(aabb.min.x, this.width),
+            minY: this.roundToCell(aabb.min.y, this.height),
+            maxX: this.roundToCell(aabb.max.x, this.width),
+            maxY: this.roundToCell(aabb.max.y, this.height),
+        };
+    }
+
+    private roundToCell(value: number, max: number): number {
+        return math.clamp(Math.floor(value / this.cellSize), 0, max);
+    }
+
+    private forEachCell(
+        bounds: GridCellBounds,
+        callback: (x: number, y: number, cellIndex: number) => void,
+    ): void {
+        for (let x = bounds.minX; x <= bounds.maxX; x++) {
+            for (let y = bounds.minY; y <= bounds.maxY; y++) {
+                callback(x, y, this.cellIndex(x, y));
+            }
+        }
+    }
+
+    private forEachCellDifference(
+        bounds: GridCellBounds,
+        excluded: GridCellBounds | undefined,
+        callback: (x: number, y: number, cellIndex: number) => void,
+    ): void {
+        for (let x = bounds.minX; x <= bounds.maxX; x++) {
+            for (let y = bounds.minY; y <= bounds.maxY; y++) {
+                if (excluded && cellInBounds(x, y, excluded)) continue;
+                callback(x, y, this.cellIndex(x, y));
+            }
+        }
+    }
+
+    private cellIndex(x: number, y: number): number {
+        return x * (this.height + 1) + y;
+    }
+
+    private rememberObject(object: T): number | undefined {
+        const id = this.registeredObjectId(object);
+        if (id === undefined) return undefined;
+        const previousObject = this.objects[id];
+        if (previousObject && previousObject !== object) {
+            throw new Error(
+                `Grid interest object ID ${id} was reused before its previous object was removed`,
+            );
+        }
+        this.objects[id] = object;
+        return id;
+    }
+
+    private registeredObjectId(object: T): number | undefined {
+        const id = this.getObjectId(object);
+        if (id === undefined || id === 0) return undefined;
+        return this.validateObjectId(id);
+    }
+
+    private validateObjectId(id: number): number {
+        if (!Number.isInteger(id) || id <= 0 || id >= this.maxObjectId) {
+            throw new RangeError(
+                `Grid interest object ID ${id} must be between 1 and ${this.maxObjectId - 1}`,
+            );
+        }
+        return id;
+    }
+
+    private validateClientSlot(clientSlot: number): number {
+        if (!Number.isInteger(clientSlot) || clientSlot < 0 || clientSlot >= this.maxClients) {
+            throw new RangeError(
+                `Grid interest client slot ${clientSlot} must be between 0 and ${this.maxClients - 1}`,
+            );
+        }
+        return clientSlot;
+    }
+
+    private client(clientSlot: number): ClientState<T> {
+        clientSlot = this.validateClientSlot(clientSlot);
+        const client = this.clients[clientSlot];
+        if (!client) throw new Error(`Client slot ${clientSlot} is not active`);
+        return client;
+    }
+
+    private get activeWordCount(): number {
+        return this.highestActiveClientSlot < 0 ? 0 : (this.highestActiveClientSlot >>> 5) + 1;
+    }
+}
+
+function defaultObjectId(object: unknown): number {
+    return (object as { __id: number }).__id;
+}
+
+function boundsEqual(first: GridCellBounds, second: GridCellBounds): boolean {
+    return first.minX === second.minX
+        && first.minY === second.minY
+        && first.maxX === second.maxX
+        && first.maxY === second.maxY;
+}
+
+function cellInBounds(x: number, y: number, bounds: GridCellBounds): boolean {
+    return x >= bounds.minX && x <= bounds.maxX && y >= bounds.minY && y <= bounds.maxY;
+}

--- a/server/src/game/objects/gameObject.ts
+++ b/server/src/game/objects/gameObject.ts
@@ -65,7 +65,7 @@ export class ObjectRegister {
     idNext = 1;
     freeLists = {} as Record<ObjectType, number[]>;
 
-    constructor(readonly grid: Grid) {
+    constructor(readonly grid: Grid<GameObject>) {
         for (let i = 0; i < MAX_ID; i++) {
             this.idToObj[i] = null;
         }

--- a/server/src/game/objects/gameObject.ts
+++ b/server/src/game/objects/gameObject.ts
@@ -57,8 +57,10 @@ export class ObjectRegister {
     idToObj: Array<GameObject | null> = [];
 
     idToType = new Uint8Array(MAX_ID);
-    dirtyPart = new Uint8Array(MAX_ID);
-    dirtyFull = new Uint8Array(MAX_ID);
+    private readonly dirtyPart = new Uint8Array(MAX_ID);
+    private readonly dirtyFull = new Uint8Array(MAX_ID);
+    private readonly dirtyQueued = new Uint8Array(MAX_ID);
+    private readonly dirtyIds: number[] = [];
 
     deletedObjs: GameObject[] = [];
 
@@ -120,8 +122,7 @@ export class ObjectRegister {
         this.objects[obj.__arrayIdx] = obj;
         this.idToObj[id] = obj;
         this.idToType[id] = type;
-        this.dirtyPart[id] = 1;
-        this.dirtyFull[id] = 1;
+        this.markDirtyId(id, true);
         this.grid.addObject(obj);
     }
 
@@ -140,6 +141,7 @@ export class ObjectRegister {
         this.idToType[obj.__id] = 0;
         this.dirtyPart[obj.__id] = 0;
         this.dirtyFull[obj.__id] = 0;
+        this.dirtyQueued[obj.__id] = 0;
 
         obj.__id = 0;
         // @ts-expect-error type is readonly for proper type to object class casting
@@ -147,9 +149,10 @@ export class ObjectRegister {
     }
 
     serializeObjs() {
-        for (let i = 0; i < this.objects.length; i++) {
-            const obj = this.objects[i]!;
-            const id = obj.__id;
+        for (let i = 0; i < this.dirtyIds.length; i++) {
+            const id = this.dirtyIds[i];
+            const obj = this.idToObj[id];
+            if (!obj) continue;
             if (this.dirtyFull[id]) {
                 obj.serializeFull();
             } else if (this.dirtyPart[id]) {
@@ -158,13 +161,56 @@ export class ObjectRegister {
         }
     }
 
+    forEachDirtyObject(callback: (obj: GameObject, full: boolean) => void): void {
+        for (let i = 0; i < this.dirtyIds.length; i++) {
+            const id = this.dirtyIds[i];
+            const obj = this.idToObj[id];
+            if (!obj) continue;
+            if (this.dirtyFull[id]) callback(obj, true);
+            else if (this.dirtyPart[id]) callback(obj, false);
+        }
+    }
+
+    isDirty(obj: GameObject): boolean {
+        return this.dirtyFull[obj.__id] !== 0 || this.dirtyPart[obj.__id] !== 0;
+    }
+
+    isFullDirty(obj: GameObject): boolean {
+        return this.dirtyFull[obj.__id] !== 0;
+    }
+
+    markDirty(obj: GameObject, full: boolean): void {
+        this.markDirtyId(obj.__id, full);
+    }
+
+    clearDirty(obj: GameObject): void {
+        const id = obj.__id;
+        this.dirtyPart[id] = 0;
+        this.dirtyFull[id] = 0;
+    }
+
+    private markDirtyId(id: number, full: boolean): void {
+        if (id <= 0 || id >= MAX_ID) return;
+        if (!this.dirtyQueued[id]) {
+            this.dirtyQueued[id] = 1;
+            this.dirtyIds.push(id);
+        }
+        if (full) this.dirtyFull[id] = 1;
+        else this.dirtyPart[id] = 1;
+    }
+
     flush() {
         for (let i = 0; i < this.deletedObjs.length; i++) {
             this.unregister(this.deletedObjs[i]);
         }
         this.deletedObjs.length = 0;
-        this.dirtyFull.fill(0);
-        this.dirtyPart.fill(0);
+        for (let i = 0; i < this.dirtyIds.length; i++) {
+            const id = this.dirtyIds[i];
+            this.dirtyFull[id] = 0;
+            this.dirtyPart[id] = 0;
+            this.dirtyQueued[id] = 0;
+        }
+        this.dirtyIds.length = 0;
     }
 }
 
@@ -249,11 +295,11 @@ export abstract class BaseGameObject {
     }
 
     setDirty() {
-        this.game.objectRegister.dirtyFull[this.__id] = 1;
+        this.game.objectRegister.markDirty(this as unknown as GameObject, true);
     }
 
     setPartDirty() {
-        this.game.objectRegister.dirtyPart[this.__id] = 1;
+        this.game.objectRegister.markDirty(this as unknown as GameObject, false);
     }
 
     checkStairs(objs: GameObject[], rad: number): Structure["stairs"][0] | undefined {
@@ -325,8 +371,7 @@ export abstract class BaseGameObject {
         }
         this.game.grid.remove(this as unknown as GameObject);
         this.game.objectRegister.deletedObjs.push(this as unknown as GameObject);
-        this.game.objectRegister.dirtyPart[this.__id] = 0;
-        this.game.objectRegister.dirtyFull[this.__id] = 0;
+        this.game.objectRegister.clearDirty(this as unknown as GameObject);
         this.destroyed = true;
     }
 }

--- a/server/src/game/objects/player.ts
+++ b/server/src/game/objects/player.ts
@@ -257,7 +257,15 @@ export class PlayerBarn {
             team = this.getSmallestTeam();
         }
 
-        const client = new Client(this.game, new NoOpSocket(), params.userId || null, "");
+        const interestSlot = this.game.clientBarn.allocateInterestSlot();
+        assert(interestSlot !== undefined, "Ran out of grid interest client slots");
+        const client = new Client(
+            this.game,
+            new NoOpSocket(),
+            params.userId || null,
+            "",
+            interestSlot,
+        );
         this.game.clientBarn.clients.push(client);
 
         const player = new Player(

--- a/tests/src/gridInterest.test.ts
+++ b/tests/src/gridInterest.test.ts
@@ -1,0 +1,288 @@
+import { describe, expect, test } from "vitest";
+import { Grid } from "../../server/src/game/grid.ts";
+import type { AABB } from "../../shared/utils/coldet.ts";
+import type { Vec2 } from "../../shared/utils/v2.ts";
+
+interface ReferenceObject {
+    __id: number;
+    __gridBounds: { min: Vec2; max: Vec2 };
+    __onGrid: boolean;
+    __gridQueryId: number;
+    bounds: AABB;
+    pos: Vec2;
+}
+
+interface ObjectPair {
+    reference: ReferenceObject;
+    interest: ReferenceObject;
+}
+
+const objectBounds = aabb(-1, -1, 1, 1);
+
+describe("Grid integrated interest", () => {
+    test("maintains exact visible membership and net changes", () => {
+        const grid = new Grid<ReferenceObject>(256, 256);
+        const index = grid.enableInterest({
+            maxObjectId: 16,
+            maxClients: 4,
+        });
+        const first = gridObject(1, 20, 20);
+        const second = gridObject(2, 100, 100);
+
+        grid.addObject(first);
+        grid.addObject(second);
+        index.updateClientView(0, aabb(0, 0, 64, 64));
+
+        expect(ids(index.visibleObjects(0))).toEqual([1]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [1], removed: [] });
+
+        // Crossing from one subscribed cell into another must not emit a false remove/add pair.
+        first.pos.x = 40;
+        grid.updateObject(first);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
+
+        first.pos.x = 120;
+        first.pos.y = 120;
+        grid.updateObject(first);
+        expect(ids(index.visibleObjects(0))).toEqual([]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [1] });
+
+        index.updateClientView(0, aabb(80, 80, 144, 144));
+        expect(ids(index.visibleObjects(0))).toEqual([1, 2]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [1, 2], removed: [] });
+    });
+
+    test("deduplicates multi-cell objects and cancels same-tick transitions", () => {
+        const grid = new Grid<ReferenceObject>(256, 256);
+        const index = grid.enableInterest({
+            maxObjectId: 16,
+            maxClients: 4,
+        });
+        const large = gridObject(1, 64, 64, aabb(-24, -24, 24, 24));
+
+        grid.addObject(large);
+        index.updateClientView(0, aabb(48, 48, 80, 80));
+        expect(ids(index.visibleObjects(0))).toEqual([1]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [1], removed: [] });
+
+        grid.remove(large);
+        grid.addObject(large);
+        expect(ids(index.visibleObjects(0))).toEqual([1]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
+
+        index.updateClientView(0, aabb(160, 160, 192, 192));
+        index.updateClientView(0, aabb(48, 48, 80, 80));
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
+    });
+
+    test("supports object ID reuse after removal and rejects it while active", () => {
+        const grid = new Grid<ReferenceObject>(256, 256);
+        const index = grid.enableInterest({
+            maxObjectId: 16,
+            maxClients: 4,
+        });
+        const oldObject = gridObject(1, 32, 32);
+        const replacement = gridObject(1, 32, 32);
+
+        grid.addObject(oldObject);
+        expect(() => grid.addObject(replacement)).toThrow(/reused before/);
+
+        index.updateClientView(0, aabb(0, 0, 64, 64));
+        index.drainChanges(0);
+        grid.remove(oldObject);
+        grid.addObject(replacement);
+
+        const changes = index.drainChanges(0);
+        expect(changes.removed).toEqual([oldObject]);
+        expect(changes.added).toEqual([replacement]);
+        expect([...index.visibleObjects(0)]).toEqual([replacement]);
+    });
+
+    test("backfills objects that entered the grid before registration assigned an ID", () => {
+        const grid = new Grid<ReferenceObject>(256, 256);
+        const index = grid.enableInterest({ maxObjectId: 16, maxClients: 4 });
+        const object = gridObject(0, 32, 32);
+
+        grid.addObject(object);
+        object.__id = 1;
+        grid.addObject(object);
+        index.updateClientView(0, aabb(0, 0, 64, 64));
+
+        expect(ids(index.visibleObjects(0))).toEqual([1]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [1], removed: [] });
+    });
+
+    test("keeps the forced active object visible without false spatial transitions", () => {
+        const grid = new Grid<ReferenceObject>(256, 256);
+        const index = grid.enableInterest({ maxObjectId: 16, maxClients: 4 });
+        const spatial = gridObject(1, 32, 32);
+        const forced = gridObject(2, 160, 160);
+
+        grid.addObject(spatial);
+        grid.addObject(forced);
+        index.updateClientView(0, aabb(0, 0, 64, 64));
+        index.setForcedObject(0, forced);
+        expect(ids(index.visibleObjects(0))).toEqual([1, 2]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [1, 2], removed: [] });
+
+        forced.pos.x = 32;
+        forced.pos.y = 32;
+        grid.updateObject(forced);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
+
+        index.setForcedObject(0, spatial);
+        expect(ids(index.visibleObjects(0))).toEqual([1, 2]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
+
+        forced.pos.x = 160;
+        forced.pos.y = 160;
+        grid.updateObject(forced);
+        expect(ids(index.visibleObjects(0))).toEqual([1]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [2] });
+    });
+
+    test("matches Grid.intersectAABBSet through randomized movement and lifecycle changes", () => {
+        const random = mulberry32(0x5eed1234);
+        const worldSize = 256;
+        const objectCount = 96;
+        const clientCount = 8;
+        const reference = new Grid<ReferenceObject>(worldSize, worldSize);
+        const incrementalGrid = new Grid<ReferenceObject>(worldSize, worldSize);
+        const incremental = incrementalGrid.enableInterest({
+            maxObjectId: objectCount + 1,
+            maxClients: clientCount,
+        });
+        const pairs: ObjectPair[] = [];
+        const activeObjects = new Uint8Array(objectCount);
+        const views: Array<AABB | undefined> = new Array(clientCount);
+
+        for (let id = 1; id <= objectCount; id++) {
+            const pair = objectPair(id, randomPosition(random), randomPosition(random));
+            pairs.push(pair);
+            activeObjects[id - 1] = 1;
+            reference.addObject(pair.reference);
+            incrementalGrid.addObject(pair.interest);
+        }
+        for (let client = 0; client < clientCount; client++) {
+            const view = randomView(random, worldSize);
+            views[client] = view;
+            incremental.updateClientView(client, view);
+            incremental.drainChanges(client);
+        }
+
+        assertEquivalent(reference, incremental, views);
+
+        for (let step = 0; step < 5_000; step++) {
+            const operation = Math.floor(random() * 10);
+            if (operation < 6) {
+                const objectIndex = Math.floor(random() * objectCount);
+                const pair = pairs[objectIndex];
+                if (activeObjects[objectIndex]) {
+                    pair.reference.pos.x = pair.interest.pos.x = randomPosition(random);
+                    pair.reference.pos.y = pair.interest.pos.y = randomPosition(random);
+                    reference.updateObject(pair.reference);
+                    incrementalGrid.updateObject(pair.interest);
+                } else {
+                    activeObjects[objectIndex] = 1;
+                    reference.addObject(pair.reference);
+                    incrementalGrid.addObject(pair.interest);
+                }
+            } else if (operation < 7) {
+                const objectIndex = Math.floor(random() * objectCount);
+                if (activeObjects[objectIndex]) {
+                    activeObjects[objectIndex] = 0;
+                    reference.remove(pairs[objectIndex].reference);
+                    incrementalGrid.remove(pairs[objectIndex].interest);
+                }
+            } else if (operation < 9) {
+                const client = Math.floor(random() * clientCount);
+                const view = randomView(random, worldSize);
+                views[client] = view;
+                incremental.updateClientView(client, view);
+            } else {
+                const client = Math.floor(random() * clientCount);
+                if (views[client]) {
+                    views[client] = undefined;
+                    incremental.removeClient(client);
+                } else {
+                    const view = randomView(random, worldSize);
+                    views[client] = view;
+                    incremental.updateClientView(client, view);
+                }
+            }
+
+            if (step % 10 === 0) assertEquivalent(reference, incremental, views);
+        }
+
+        assertEquivalent(reference, incremental, views);
+    });
+});
+
+function assertEquivalent(
+    reference: Grid<ReferenceObject>,
+    incremental: ReturnType<Grid<ReferenceObject>["enableInterest"]>,
+    views: Array<AABB | undefined>,
+): void {
+    for (let client = 0; client < views.length; client++) {
+        const view = views[client];
+        if (!view) continue;
+        expect(ids(incremental.visibleObjects(client)), `client ${client}`).toEqual(
+            ids(reference.intersectAABBSet(view)),
+        );
+    }
+}
+
+function objectPair(id: number, x: number, y: number): ObjectPair {
+    return {
+        reference: gridObject(id, x, y),
+        interest: gridObject(id, x, y),
+    };
+}
+
+function gridObject(id: number, x: number, y: number, bounds = objectBounds): ReferenceObject {
+    return {
+        __id: id,
+        __gridBounds: { min: { x: -1, y: -1 }, max: { x: -1, y: -1 } },
+        __onGrid: false,
+        __gridQueryId: 0,
+        bounds,
+        pos: { x, y },
+    };
+}
+
+function aabb(minX: number, minY: number, maxX: number, maxY: number): AABB {
+    return { type: 1, min: { x: minX, y: minY }, max: { x: maxX, y: maxY } };
+}
+
+function ids(objects: Iterable<{ __id: number }>): number[] {
+    return [...objects].map(object => object.__id).sort((a, b) => a - b);
+}
+
+function changeIds(changes: { added: ReferenceObject[]; removed: ReferenceObject[] }) {
+    return {
+        added: ids(changes.added),
+        removed: ids(changes.removed),
+    };
+}
+
+function randomView(random: () => number, worldSize: number): AABB {
+    const halfWidth = 24 + random() * 48;
+    const halfHeight = 16 + random() * 32;
+    const x = random() * worldSize;
+    const y = random() * worldSize;
+    return aabb(x - halfWidth, y - halfHeight, x + halfWidth, y + halfHeight);
+}
+
+function randomPosition(random: () => number): number {
+    return -32 + random() * 320;
+}
+
+function mulberry32(seed: number): () => number {
+    return () => {
+        seed |= 0;
+        seed = seed + 0x6d2b79f5 | 0;
+        let value = Math.imul(seed ^ seed >>> 15, 1 | seed);
+        value = value + Math.imul(value ^ value >>> 7, 61 | value) ^ value;
+        return ((value ^ value >>> 14) >>> 0) / 4294967296;
+    };
+}

--- a/tests/src/gridInterest.test.ts
+++ b/tests/src/gridInterest.test.ts
@@ -168,6 +168,42 @@ describe("Grid integrated interest", () => {
         expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [2] });
     });
 
+    test("routes only spatial clients and preserves Set order after re-entry", () => {
+        const grid = new Grid<ReferenceObject>(256, 256);
+        const index = grid.enableInterest({ maxObjectId: 16, maxClients: 4 });
+        const first = gridObject(1, 32, 32);
+        const second = gridObject(2, 36, 32);
+        const third = gridObject(3, 40, 32);
+        const forced = gridObject(4, 160, 160);
+
+        grid.addObject(first);
+        grid.addObject(second);
+        grid.addObject(third);
+        grid.addObject(forced);
+        index.updateClientView(0, aabb(0, 0, 64, 64));
+        index.setForcedObject(0, forced);
+        index.drainChanges(0);
+
+        const spatialClients: number[] = [];
+        index.forEachSpatialClient(second, client => spatialClients.push(client));
+        expect(spatialClients).toEqual([0]);
+
+        const forcedClients: number[] = [];
+        index.forEachSpatialClient(forced, client => forcedClients.push(client));
+        expect(forcedClients).toEqual([]);
+        expect(index.isSpatiallyVisible(forced, 0)).toBe(false);
+
+        grid.remove(second);
+        grid.addObject(second);
+        index.flushObjectUpdates();
+
+        const visible = [...index.visibleObjects(0)];
+        expect(visible.map(object => object.__id)).toEqual([1, 3, 4, 2]);
+        expect(visible.map(object => index.visibilityOrder(0, object))).toEqual(
+            [...visible].map(object => index.visibilityOrder(0, object)).toSorted((a, b) => a - b),
+        );
+    });
+
     test("matches Grid.intersectAABBSet through randomized movement and lifecycle changes", () => {
         const random = mulberry32(0x5eed1234);
         const worldSize = 256;

--- a/tests/src/gridInterest.test.ts
+++ b/tests/src/gridInterest.test.ts
@@ -39,11 +39,15 @@ describe("Grid integrated interest", () => {
         // Crossing from one subscribed cell into another must not emit a false remove/add pair.
         first.pos.x = 40;
         grid.updateObject(first);
+        index.flushObjectUpdates();
         expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
 
         first.pos.x = 120;
         first.pos.y = 120;
         grid.updateObject(first);
+        expect(ids(index.visibleObjects(0))).toEqual([1]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
+        index.flushObjectUpdates();
         expect(ids(index.visibleObjects(0))).toEqual([]);
         expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [1] });
 
@@ -67,6 +71,7 @@ describe("Grid integrated interest", () => {
 
         grid.remove(large);
         grid.addObject(large);
+        index.flushObjectUpdates();
         expect(ids(index.visibleObjects(0))).toEqual([1]);
         expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
 
@@ -91,11 +96,31 @@ describe("Grid integrated interest", () => {
         index.drainChanges(0);
         grid.remove(oldObject);
         grid.addObject(replacement);
+        index.flushObjectUpdates();
 
         const changes = index.drainChanges(0);
         expect(changes.removed).toEqual([oldObject]);
         expect(changes.added).toEqual([replacement]);
         expect([...index.visibleObjects(0)]).toEqual([replacement]);
+    });
+
+    test("resolves pending movement before a client slot is removed and reused", () => {
+        const grid = new Grid<ReferenceObject>(256, 256);
+        const index = grid.enableInterest({ maxObjectId: 16, maxClients: 1 });
+        const object = gridObject(1, 32, 32);
+
+        grid.addObject(object);
+        index.updateClientView(0, aabb(0, 0, 64, 64));
+        index.drainChanges(0);
+
+        object.pos.x = 160;
+        object.pos.y = 160;
+        grid.updateObject(object);
+        index.removeClient(0);
+        index.updateClientView(0, aabb(128, 128, 192, 192));
+
+        expect(ids(index.visibleObjects(0))).toEqual([1]);
+        expect(changeIds(index.drainChanges(0))).toEqual({ added: [1], removed: [] });
     });
 
     test("backfills objects that entered the grid before registration assigned an ID", () => {
@@ -128,6 +153,7 @@ describe("Grid integrated interest", () => {
         forced.pos.x = 32;
         forced.pos.y = 32;
         grid.updateObject(forced);
+        index.flushObjectUpdates();
         expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [] });
 
         index.setForcedObject(0, spatial);
@@ -137,6 +163,7 @@ describe("Grid integrated interest", () => {
         forced.pos.x = 160;
         forced.pos.y = 160;
         grid.updateObject(forced);
+        index.flushObjectUpdates();
         expect(ids(index.visibleObjects(0))).toEqual([1]);
         expect(changeIds(index.drainChanges(0))).toEqual({ added: [], removed: [2] });
     });
@@ -211,7 +238,7 @@ describe("Grid integrated interest", () => {
                 }
             }
 
-            if (step % 10 === 0) assertEquivalent(reference, incremental, views);
+            if (step % 10 === 0) assertEquivalent(reference, incremental, views, `step ${step}`);
         }
 
         assertEquivalent(reference, incremental, views);
@@ -222,11 +249,13 @@ function assertEquivalent(
     reference: Grid<ReferenceObject>,
     incremental: ReturnType<Grid<ReferenceObject>["enableInterest"]>,
     views: Array<AABB | undefined>,
+    context = "final",
 ): void {
+    incremental.flushObjectUpdates();
     for (let client = 0; client < views.length; client++) {
         const view = views[client];
         if (!view) continue;
-        expect(ids(incremental.visibleObjects(client)), `client ${client}`).toEqual(
+        expect(ids(incremental.visibleObjects(client)), `${context}, client ${client}`).toEqual(
             ids(reference.intersectAABBSet(view)),
         );
     }

--- a/tests/src/objectRegister.test.ts
+++ b/tests/src/objectRegister.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "vitest";
+import type { Grid } from "../../server/src/game/grid.ts";
+import { type GameObject, ObjectRegister } from "../../server/src/game/objects/gameObject.ts";
+
+describe("ObjectRegister dirty queue", () => {
+    test("deduplicates dirty objects and lets full updates override partial updates", () => {
+        const register = new ObjectRegister({} as Grid<GameObject>);
+        const serialized = { full: 0, partial: 0 };
+        const object = {
+            __id: 42,
+            serializeFull: () => serialized.full++,
+            serializePartial: () => serialized.partial++,
+        } as unknown as GameObject;
+        register.idToObj[object.__id] = object;
+
+        register.markDirty(object, false);
+        register.markDirty(object, false);
+        register.markDirty(object, true);
+
+        const routed: Array<{ object: GameObject; full: boolean }> = [];
+        register.forEachDirtyObject((dirtyObject, full) => {
+            routed.push({ object: dirtyObject, full });
+        });
+        register.serializeObjs();
+
+        expect(routed).toEqual([{ object, full: true }]);
+        expect(serialized).toEqual({ full: 1, partial: 0 });
+
+        register.flush();
+        expect(register.isDirty(object)).toBe(false);
+        expect(Array.from(dirtyObjects(register))).toEqual([]);
+    });
+
+    test("can be cleared and marked again before the queue is flushed", () => {
+        const register = new ObjectRegister({} as Grid<GameObject>);
+        const object = { __id: 7 } as GameObject;
+        register.idToObj[object.__id] = object;
+
+        register.markDirty(object, true);
+        register.clearDirty(object);
+        expect(Array.from(dirtyObjects(register))).toEqual([]);
+
+        register.markDirty(object, false);
+        expect(Array.from(dirtyObjects(register))).toEqual([{ object, full: false }]);
+    });
+});
+
+function* dirtyObjects(register: ObjectRegister) {
+    const objects: Array<{ object: GameObject; full: boolean }> = [];
+    register.forEachDirtyObject((object, full) => objects.push({ object, full }));
+    yield* objects;
+}


### PR DESCRIPTION
pr is mostly ai with some guidance from me.

this is an exploration about ways to make the grid do less calculations, treat the current code as disposable, there is some leftovers in the branch but cba to clean it up 

i made the ai write a not so bad explanation of the PR and how it was tested just for mamoun's convience, how nice of me.


## What this changes

The existing grid already does its job well.

The map is divided into 16×16 cells, and each cell contains the players, loot, buildings, projectiles, and other objects touching it. This lets collision queries inspect a small part of the map instead of every object in the game.

The expensive part happens when the server prepares updates for connected players.

For every player, on every network sync, the old code:

1. Takes the player’s camera bounds.
2. Finds every grid cell inside them.
3. Scans the objects in those cells.
4. Builds a new `visibleObjects` set.
5. Compares it with the previous set.

Consider a player standing beside ten loot items, a few buildings, and several obstacles.

Nothing moves, but the server still visits the same cells, finds the same objects, creates another `Set`, and compares it with the previous one. It repeats that work for every connected player 33 times per second.

The old grid keeps answering the same question:

> Which objects can this player see right now?

This PR makes the grid remember the answer.

## Remembering visibility

Each connected player receives a stable numbered interest slot:

```text
Player A → slot 0
Player B → slot 1
Player C → slot 2
Player D → slot 3
```

Each grid cell then represents the players who can see it using bits:

```text
player:  H G F E D C B A
mask:    0 0 0 0 1 1 0 1
```

That mask says players A, C, and D can see the cell.

With 80 connected players, a cell’s complete subscriber list fits in three 32-bit words. This lets one operation update visibility information for 32 players at once without allocating a `Set` of client objects.

An object may touch several cells. Its visibility mask is the OR of the masks belonging to those cells:

```text
Cell 1:   00000101
Cell 2:   00000110
          ──────── OR
Object:   00000111
```

The result says the object is visible to players A, B, and C.

When the object moves, the grid compares its previous and new masks with XOR:

```text
Old:      00010101
New:      00011100
          ──────── XOR
Changed:  00001001
```

Only the enabled bits changed. Those are the only players whose visibility needs to be updated. Everyone represented by a zero is left untouched.

This changes the cost from scanning everything currently visible to processing only the relationships that changed.

## Camera movement

A camera usually overlaps almost the same cells as it did during the previous update.

When it crosses one cell boundary, only one strip leaves the camera and another enters:

```text
Before:          After:

████████         ·████████
████████    →    ·████████
████████         ·████████
```

The unchanged middle does not need to be scanned again.

The grid removes the player’s subscriber bit from cells leaving the camera, adds it to cells entering the camera, and recomputes only the objects found in those changed cells.

If the camera still rounds to the same grid-cell bounds, no visibility work is needed.

## Reusing the existing grid

This could have been implemented as a second spatial grid dedicated to visibility, but then every moving player and projectile would need to update both structures.

Instead, interest tracking extends the existing collision grid.

The collision grid already knows when an object enters or leaves a cell. The new tracker reuses that membership and adds only the information needed for networking:

- Which clients subscribe to each cell
- Which clients can see each object
- Which objects each client currently sees
- Which objects were added or removed since the previous packet

There is no second spatial index and no duplicated position tracking.

## Performance

According to the trust me benchmark 2,400 objects and up to 80 clients, the new tracker was 3.17× faster in the quiet workload, 2.63× faster in the typical workload, and 1.47× faster in the busy workload.

looking for feedback on how to profile this even better, or some actual game recordings to test with

## Correctness

The final implementation was temporarily run beside the previous grid query during real 79-bot games. At the network-sync boundary, the server compared visible objects, additions, removals, full updates, partial updates, and deletion IDs. A normal match and a churn match with 20 confirmed interest-slot reuses produced 999,778 client comparisons and 43,604,568 candidate-object results with zero mismatches. A deterministic 5,000-operation lifecycle test covers movement, camera changes, forced visibility, removal, recreation, and ID reuse.
