### PR TITLE
add empty vitest config

### DIFF
--- a/tests/vitest.config.ts
+++ b/tests/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({});


### PR DESCRIPTION
without a vite/vitest config somewhere, the vitest extension for vscode doesn't attempt test discovery
adding this empty config just allows the extension to function properly, without impacting anyone else
test suite has no regressions