### PR TITLE
fix: make weapon fire rate run independently of server tps

### DIFF
--- a/server/src/game/weaponManager.ts
+++ b/server/src/game/weaponManager.ts
@@ -350,9 +350,18 @@ export class WeaponManager {
             this.tryReload();
         }
 
+        if (!player.shootHold && weapon.ammo > 0 && weapon.cooldown < 0) {
+            weapon.cooldown = 0;
+        }
+
         switch (itemDef.fireMode) {
             case "auto":
-                if (player.shootHold && weapon.cooldown <= 0) {
+                while (player.shootHold && weapon.cooldown <= 0) {
+                    if (weapon.ammo > 0) {
+                        weapon.cooldown += itemDef.fireDelay;
+                    } else {
+                        break;
+                    }
                     this.fireWeapon(this.offHand);
                     this.offHand = !this.offHand;
                 }
@@ -360,6 +369,7 @@ export class WeaponManager {
             case "single":
                 if (player.shootStart) {
                     if (weapon.cooldown < 0) {
+                        weapon.cooldown = itemDef.fireDelay;
                         this.fireWeapon(this.offHand);
                         this.offHand = !this.offHand;
                     } else if (weapon.cooldown < 0.1) {
@@ -369,7 +379,6 @@ export class WeaponManager {
                 break;
             case "burst":
                 if (player.shootHold && weapon.cooldown < 0) {
-                    weapon.cooldown = 0;
                     for (let i = 0; i < itemDef.burstCount!; i++) {
                         this.bursts.push(weapon.cooldown);
                         weapon.cooldown += itemDef.burstDelay!;
@@ -689,7 +698,6 @@ export class WeaponManager {
 
         const firstShotAccuracy = weapon.recoilTime <= 0;
 
-        weapon.cooldown = itemDef.fireDelay;
         weapon.recoilTime = itemDef.recoilTime;
 
         // Check firing location


### PR DESCRIPTION
TODO:
More testing? I think SPAS-12, Mosin, and other semi-auto weapons work fine, not really sure how much I'm supposed to test though....

This fix makes weapons fire at roughly the same firing rate, no matter how slow the server ticks per second is.

Regular 100 TPS (unchanged)

https://github.com/user-attachments/assets/b5dd4850-b894-4c91-8a9f-77eeefd3ad59

Old 15 TPS

https://github.com/user-attachments/assets/fc26a064-1c1a-4d04-a811-78b2538d8868

New 15 TPS


https://github.com/user-attachments/assets/acda2864-03f0-4c40-bcce-d512462faf38

