### PR TITLE
enhance: replace most Arial instances with Roboto Condensed

### DIFF
--- a/client/css/app.css
+++ b/client/css/app.css
@@ -3024,7 +3024,7 @@ a:active {
   position: fixed;
   overflow: hidden;
   box-sizing: border-box;
-  font-family: Helvetica, Calibri, Arial, sans-serif;
+  font-family: "Roboto Condensed", Helvetica, Calibri, Arial, sans-serif;
   font-size: 16px;
   line-height: 1.5em;
   display: flex;

--- a/client/src/map.ts
+++ b/client/src/map.ts
@@ -630,7 +630,7 @@ export class Map {
             for (let i = 0; i < places.length; i++) {
                 const place = places[i];
                 const style = new PIXI.TextStyle({
-                    fontFamily: "Arial",
+                    fontFamily: "Roboto Condensed, Arial, sans-serif",
                     fontSize: device.mobile ? 20 : 22,
                     fontWeight: "bold",
                     fill: ["#ffffff"],

--- a/client/src/objects/deadBody.ts
+++ b/client/src/objects/deadBody.ts
@@ -13,7 +13,7 @@ import type { AbstractObject, Player, PlayerBarn } from "./player.ts";
 
 function createDeadBodyText() {
     const nameStyle: Partial<PIXI.TextStyle> = {
-        fontFamily: "Arial",
+        fontFamily: "Roboto Condensed, Arial, sans-serif",
         fontWeight: "bold",
         fontSize: device.pixelRatio > 1 ? 30 : 24,
         align: "center",

--- a/client/src/objects/player.ts
+++ b/client/src/objects/player.ts
@@ -59,7 +59,7 @@ function perksEqual(a: Array<{ type: string }>, b: Array<{ type: string }>) {
 }
 function createPlayerNameText() {
     const nameStyle = {
-        fontFamily: "Arial",
+        fontFamily: "Roboto Condensed, Arial, sans-serif",
         fontWeight: "bold",
         fontSize: device.pixelRatio > 1 ? 30 : 22,
         align: "center",
@@ -2801,7 +2801,7 @@ export class PlayerBarn {
             name: info.name,
             nameTruncated: helpers.truncateString(
                 info.name || "",
-                "bold 16px arial",
+                "bold 16px 'Roboto Condensed'",
                 180,
             ),
             anonName: `Player${info.playerId - 2750}`,


### PR DESCRIPTION
*kinda supersedes #386*

I was looking back my old branches and noticed that by far the scopes were the most contentious part in the dev server

[I also did this in resurviv](https://github.com/NAMERIO/resurviv/pull/29) and it seems like nobody really disliked it